### PR TITLE
Added cascade look up for settings files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,13 @@ pip install dynaconf
 ```
 
 > NOTE: this project officially supports and encourages only Python 3+. Currently this is working well and tests are passing on any Python version above 2.7 but at any moment we can drop python2.x support if needed.
+# settings module
+
+If you have a settings.py, settings.yml or a settings.yaml in project's root, dynaconf will load it for you.
+Otherwise see next section.
 
 # define your settings module
+
 
 ```bash
 export DYNACONF_SETTINGS=myproject.settings

--- a/dynaconf/default_settings.py
+++ b/dynaconf/default_settings.py
@@ -1,9 +1,15 @@
 # default proj root
 # pragma: no cover
+from os import path
+
 PROJECT_ROOT = "."
 
-# Default settings file
-SETTINGS_MODULE_FOR_DYNACONF = 'settings.py'
+for _config_file in ('settings.py', 'settings.yml', 'settings.yaml'):
+    if path.exists(path.join(PROJECT_ROOT, _config_file)):
+        SETTINGS_MODULE_FOR_DYNACONF = _config_file
+        break
+else:
+    SETTINGS_MODULE_FOR_DYNACONF = 'settings.py'
 
 # Namespace for envvars
 DYNACONF_NAMESPACE = 'DYNACONF'

--- a/dynaconf/loaders/yaml_loader.py
+++ b/dynaconf/loaders/yaml_loader.py
@@ -64,7 +64,7 @@ def load(obj, namespace=None, silent=True, key=None, filename=None):
         data = {}
         try:
             data = yaml_data[namespace.lower()]
-        except KeyError as e:
+        except KeyError:
             if silent:
                 if hasattr(obj, 'logger'):
                     obj.logger.debug(

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def parse_md_to_rst(file):
 
 setup(
     name='dynaconf',
-    version="0.5.2",
+    version="0.6",
     url='https://github.com/rochacbruno/dynaconf',
     license='MIT',
     author="Bruno Rocha",


### PR DESCRIPTION
#close 31

It will look on on this order for settings.py, settings.yml or settings.yaml on root directory. E.g. if you already have a settings.py it will ignore the the other 2 extensions.