### PR TITLE
Added cascade look up for settings files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,13 @@ pip install dynaconf
 ```
 
 > NOTE: this project officially supports and encourages only Python 3+. Currently this is working well and tests are passing on any Python version above 2.7 but at any moment we can drop python2.x support if needed.
+# settings module
+
+If you have a settings.py, settings.yml or a settings.yaml in project's root, dynaconf will load it for you.
+Otherwise see next section.
 
 # define your settings module
+
 
 ```bash
 export DYNACONF_SETTINGS=myproject.settings

--- a/dynaconf/default_settings.py
+++ b/dynaconf/default_settings.py
@@ -1,9 +1,31 @@
 # default proj root
 # pragma: no cover
+from os import path
+
 PROJECT_ROOT = "."
 
-# Default settings file
-SETTINGS_MODULE_FOR_DYNACONF = 'settings.py'
+_found_config_files = [
+    f for f in ('settings.py', 'settings.yml', 'settings.yaml')
+    if path.exists(path.join(PROJECT_ROOT, f))
+]
+if len(_found_config_files) == 0:
+    _found_config_files.append('settings.py')
+
+
+class MultipleConfigFilesError(Exception):
+    pass
+
+
+if len(_found_config_files) > 1:
+    raise MultipleConfigFilesError(
+        'Found multiple config files on root directory: {}. '
+        'Only one settings file is allowed. '
+        'So you can change change file names and use DYNACONF_SETTINGS '
+        'env var to set the file you want to use'.format(
+            '.'.join(_found_config_files))
+    )
+
+SETTINGS_MODULE_FOR_DYNACONF = _found_config_files[0]
 
 # Namespace for envvars
 DYNACONF_NAMESPACE = 'DYNACONF'

--- a/dynaconf/loaders/yaml_loader.py
+++ b/dynaconf/loaders/yaml_loader.py
@@ -64,7 +64,7 @@ def load(obj, namespace=None, silent=True, key=None, filename=None):
         data = {}
         try:
             data = yaml_data[namespace.lower()]
-        except KeyError as e:
+        except KeyError:
             if silent:
                 if hasattr(obj, 'logger'):
                     obj.logger.debug(

--- a/example/yaml_example/multiple_settings_module/app.py
+++ b/example/yaml_example/multiple_settings_module/app.py
@@ -1,0 +1,13 @@
+from dynaconf import settings
+
+#It will raise MultipleConfigFileError because there are multiple config files on root
+print(settings.HOST)
+print(settings.PORT)
+print(settings.USERNAME)
+print(settings.PASSWORD)
+print(settings.LEVELS)
+print(settings.TEST_LOADERS)
+print(settings.MONEY)
+print(settings.AGE)
+print(settings.ENABLED)
+

--- a/example/yaml_example/multiple_settings_module/env.sh
+++ b/example/yaml_example/multiple_settings_module/env.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+export DYNACONF_SETTINGS=settings.yaml

--- a/example/yaml_example/multiple_settings_module/settings.py
+++ b/example/yaml_example/multiple_settings_module/settings.py
@@ -1,0 +1,9 @@
+HOST = 'server.com'
+PORT = 500
+USERNAME = 'ADMIN'
+PASSWORD = 'secret'
+LEVELS = 'debug info warning'.split()
+TEST_LOADERS = {'dev': 'test_dev', 'prod': 'test_produ'}
+MONEY = 500.50
+AGE = 42
+ENABLED = True

--- a/example/yaml_example/multiple_settings_module/settings.yaml
+++ b/example/yaml_example/multiple_settings_module/settings.yaml
@@ -1,0 +1,18 @@
+dynaconf:
+  host: server.com
+  port: 5000
+  username: admin
+  PASSWORD: Secret
+  levels:
+    - debug
+    - info
+    - warning
+  test_loaders:
+    dev: test_dev
+    prod: test_prod
+  money: 500.50
+  age: 42
+  enabled: true
+development:
+  environment: this is development
+  host: dev_server.com

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def parse_md_to_rst(file):
 
 setup(
     name='dynaconf',
-    version="0.5.2",
+    version="0.6",
     url='https://github.com/rochacbruno/dynaconf',
     license='MIT',
     author="Bruno Rocha",


### PR DESCRIPTION
#close 31

It will look, on this order, for settings.py, settings.yml or settings.yaml on root directory.

I created this PR as an option during this discussion: https://github.com/rochacbruno/dynaconf/pull/32#pullrequestreview-71213291