### PR TITLE
Added Django extension

### DIFF
--- a/dynaconf/contrib/django_dynaconf/__init__.py
+++ b/dynaconf/contrib/django_dynaconf/__init__.py
@@ -1,0 +1,16 @@
+# coding: utf-8
+import django
+from dynaconf import LazySettings
+
+
+django_settings = {}
+for key in dir(django.conf.settings):
+    if key.isupper():
+        django_settings[key] = getattr(django.conf.settings, key, None)
+
+
+django_settings['SETTINGS_MODULE'] = django_settings.get(
+    'DYNACONF_SETTINGS_MODULE', 'settings.yml'
+)
+
+django.conf.settings = LazySettings(**django_settings)

--- a/dynaconf/contrib/django_dynaconf/apps.py
+++ b/dynaconf/contrib/django_dynaconf/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class BarConfig(AppConfig):
+    name = 'dj_dynaconf'

--- a/dynaconf/contrib/flask_dynaconf.py
+++ b/dynaconf/contrib/flask_dynaconf.py
@@ -1,6 +1,9 @@
 # coding: utf-8
-from flask.config import Config
 from dynaconf import LazySettings
+try:
+    from flask.config import Config
+except ImportError:
+    Config = object
 
 
 class FlaskDynaconf(object):


### PR DESCRIPTION
IN django project use `dynaconf.contrib.django_dynaconf` as the first app

```py
# mandatory
INSTALLED_APPS = [
    'dynaconf.contrib.django_dynaconf',
    'django.contrib.admin',
    ...
]

# optional
DYNACONF_SETTINGS_MODULE = 'my_settings.yml'   # default to settings.yml in the the same folder as manage.py

DYNACONF_NAMESPACE = 'DJANGO'  # default to DYNACONF

*ANY_OTHER_DYNACONF_VARIABLE_HERE
```

Now just use `from django.conf import settings` and it will include dynaconf settings.



![dyna_django2](https://user-images.githubusercontent.com/458654/31973613-ba081f94-b905-11e7-8830-9d7a4dac8da7.png)


## Caveats

Django config variables, such as MIDDLEWARES, INSTALLED_APPS etc still needs to be in `settings.py` and the dynaconf settings will be valid only for application specific settings.

## Solution 2

If it is needed to have Django settings in DYNACONF one can go to `manage.py` and `wsgi.py` and call from there `from dynaconf.contrib import django_dynaconf`


