### PR TITLE
Added config AUTO_CAST_FOR_DYNACONF=off|0|disabled|false

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,8 @@ You have 2 ways to use the casts.
 
 ### Casting on declaration
 
-Just start your ENV settigs with this
+Dynaconf uses the `AUTO_CAST` of envvars, just start your ENV vars names with a
+typed prefix like in the examples below.
 
 ```bash
 export DYNACONF_DEFAULT_THEME='material'
@@ -395,6 +396,10 @@ export DYNACONF_ALLOWED_EXTENSIONS='@json ["jpg", "png"]'
 ```
 
 Starting the settings values with @ will make dynaconf.settings to cast it in the time od load.
+
+There is support for `@int, @float, @bool, @json, @note`
+
+> **NOTE:** To disable the AUTO_CAST you can set a env var `export AUTO_CAST_FOR_DYNACONF=off`
 
 ### Casting on access
 

--- a/dynaconf/utils/boxing.py
+++ b/dynaconf/utils/boxing.py
@@ -5,25 +5,25 @@ from box import Box
 
 class DynaBox(Box):
     """Specialized Box for dynaconf
-    it allows items/attrs to be founf both in upper or lower case"""
+    it allows items/attrs to be found both in upper or lower case"""
 
-    def __getattr__(self, item):
+    def __getattr__(self, item, *args, **kwargs):
         try:
-            return super(DynaBox, self).__getattr__(item)
+            return super(DynaBox, self).__getattr__(item, *args, **kwargs)
         except (AttributeError, KeyError):
             n_item = item.lower() if item.isupper() else item.upper()
-            return super(DynaBox, self).__getattr__(n_item)
+            return super(DynaBox, self).__getattr__(n_item, *args, **kwargs)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item, *args, **kwargs):
         try:
-            return super(DynaBox, self).__getitem__(item)
+            return super(DynaBox, self).__getitem__(item, *args, **kwargs)
         except (AttributeError, KeyError):
             n_item = item.lower() if item.isupper() else item.upper()
-            return super(DynaBox, self).__getitem__(n_item)
+            return super(DynaBox, self).__getitem__(n_item, *args, **kwargs)
 
-    def get(self, item, default=None):
-        value = super(DynaBox, self).get(item, default)
+    def get(self, item, default=None, *args, **kwargs):
+        value = super(DynaBox, self).get(item, default, *args, **kwargs)
         if value is None or value == default:
             n_item = item.lower() if item.isupper() else item.upper()
-            value = super(DynaBox, self).get(n_item, default)
+            value = super(DynaBox, self).get(n_item, default, *args, **kwargs)
         return value

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -1,9 +1,12 @@
+import os
 import json
 
 from six import string_types
 from dynaconf.utils.boxing import DynaBox
 
 true_values = ('t', 'true', 'enabled', '1', 'on', 'yes')
+false_values = ('f', 'false', 'disabled', '0', 'off', 'no')
+
 converters = {
     '@int': int,
     '@float': float,
@@ -32,6 +35,10 @@ def _parse_conf_data(data):
     export DYNACONF_MONGODB_SETTINGS='@json {"DB": "quokka_db"}'
     export DYNACONF_ALLOWED_EXTENSIONS='@json ["jpg", "png"]'
     """
+    cast_toggler = os.environ.get('AUTO_CAST_FOR_DYNACONF', '').lower()
+    if cast_toggler in false_values:
+        return data
+
     if data and isinstance(
             data, string_types
     ) and data.startswith(tuple(converters.keys())):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,3 +61,11 @@ def test_find_file():
     with open(filename, 'w') as f:
         f.write("TEST=test\n")
     assert find_file(usecwd=True) == filename
+
+
+def test_disable_cast():
+    # this casts for int
+    assert parse_conf_data('@int 42') == 42
+    # now gives pure string
+    os.environ['AUTO_CAST_FOR_DYNACONF'] = 'off'
+    assert parse_conf_data('@int 42') == '@int 42'


### PR DESCRIPTION
Suggested by @danilobellini

To disable the automatic envvar casting like `@int 42` now it is possible to do:

```bash
export AUTO_CAST_FOR_DYNACONF=off
```