### PR TITLE
Add ENCODING_FOR_DYNACONF to handle different file encoding Fix #81

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -3,6 +3,11 @@ Changelog
 
 These are all the changes in Dynaconf since the first public release.
 
+1.0.6 - Unreleased
+-----
+
+- Fixed issue #81 -  added ENCODING_FOR_DYNACONF to handle different settings files encodings specially on Windows
+
 1.0.5
 -----
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 test_examples:
 	@cd example/common;pwd;python program.py
+	@cd example/common-encoding;pwd;python program.py
 	@cd example/;pwd;python full_example.py | grep -c full_example
 	@cd example/;pwd;python compat.py
 	@cd example/app;pwd;python app.py | grep -c app

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **dynaconf** - The **dyna**mic **conf**igurator for your Python Project
 
-[![MIT License](https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square)](/LICENSE) [![PyPI](https://img.shields.io/pypi/v/dynaconf.svg)](https://pypi.python.org/pypi/dynaconf) [![PyPI](https://img.shields.io/pypi/pyversions/dynaconf.svg)]() [![Travis CI](http://img.shields.io/travis/rochacbruno/dynaconf.svg)](https://travis-ci.org/rochacbruno/dynaconf) [![codecov](https://codecov.io/gh/rochacbruno/dynaconf/branch/master/graph/badge.svg)](https://codecov.io/gh/rochacbruno/dynaconf) [![Codacy grade](https://img.shields.io/codacy/grade/5074f5d870a24ddea79def463453545b.svg)](https://www.codacy.com/app/rochacbruno/dynaconf/dashboard)
+[![MIT License](https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square)](/LICENSE) [![PyPI](https://img.shields.io/pypi/v/dynaconf.svg)](https://pypi.python.org/pypi/dynaconf) [![PyPI](https://img.shields.io/pypi/pyversions/dynaconf.svg)]() [![Travis CI](http://img.shields.io/travis/rochacbruno/dynaconf.svg)](https://travis-ci.org/rochacbruno/dynaconf) [![codecov](https://codecov.io/gh/rochacbruno/dynaconf/branch/master/graph/badge.svg)](https://codecov.io/gh/rochacbruno/dynaconf) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/5074f5d870a24ddea79def463453545b)](https://www.codacy.com/app/rochacbruno/dynaconf?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=rochacbruno/dynaconf&amp;utm_campaign=Badge_Grade)
 
 **dynaconf** a layered configuration system for Python applications -
 with strong support for [12-factor applications](https://12factor.net/config)
@@ -49,7 +49,7 @@ $ pip3 install dynaconf
 $ pip install dynaconf
 ```
 
-> Default installation supports .toml, .py and .json file formats and also environment variables (.env supported)
+> Default installation supports .toml, .py and .json file formats and also environment variables (.env supported) - to support YAML add `pip install dynaconf[yaml]` or `pip install dynaconf[all]`
 
 ## Usage
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -9,7 +9,9 @@ Dynaconf can be configured through variables suffixed with `_FOR_DYNACONF` those
 +-----------------+---------+--------------------------------------------------+-------------------------+--------------------------------------------------------------+
 | PROJECT_ROOT    | str     | Directory to look for settings                   | "."                     | PROJECT_ROOT_FOR_DYNACONF="/tmp"                             |
 +-----------------+---------+--------------------------------------------------+-------------------------+--------------------------------------------------------------+
-| SETTINGS_MODULE | str     | List of comma separated files to load            | List of supportes files | SETTINGS_MODULE_FOR_DYNACONF= "config.toml,settings.yaml"    |
+| ENCODING        | str     | Encoding to read settings files                  | utf-8                   | ENCODING_FOR_DYNACONF="cp1252"                               |
++-----------------+---------+--------------------------------------------------+-------------------------+--------------------------------------------------------------+
+| SETTINGS_MODULE | str     | List of comma separated files to load            | List of supportes files | SETTINGS_MODULE_FOR_DYNACONF="config.toml,settings.yaml"     |
 +-----------------+---------+--------------------------------------------------+-------------------------+--------------------------------------------------------------+
 | ENV             | str     | Working environment                              | "development"           | ENV_FOR_DYNACONF=production                                  |
 +-----------------+---------+--------------------------------------------------+-------------------------+--------------------------------------------------------------+

--- a/docs/guides/usage.md
+++ b/docs/guides/usage.md
@@ -8,7 +8,7 @@
 $ pip install dynaconf
 ```
 
-> Default installation supports .toml, .py and .json file formats and also environment variables (.env supported)
+> Default installation supports .toml, .py and .json file formats and also environment variables (.env supported) - to support YAML add `pip install dynaconf[yaml]` or `pip install dynaconf[all]`
 
 ## Usage
 
@@ -66,6 +66,8 @@ ENV_FOR_DYNACONF=staging python yourapp.py
 > **NOTE:** When using [FLask Extension](flask.html) the environment can be changed via `FLASK_ENV` variable and for [Django Extension](django.html) you can use `DJANGO_ENV`.
 
 ## The settings files
+
+> IMPORTANT: Dynaconf by default reads settings files using `utf-8` encoding, if you have settings files written in other encoding please set `ENCODING_FOR_DYNACONF` environment variable see more in [configuration](configuration.html)
 
 An optional `settings.{toml|py|json|ini|yaml}` file can be used to specify the configuration parameters for each environment. If it is not present, only the values from **environment variables** are used (**.env** file is also supported). Dynaconf searches for the file starting at the current working directory. If it is not found there, Dynaconf checks the parent directory. Dynaconf continues checking parent directories until the root is reached.
 

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -46,6 +46,8 @@ ENVS = ['default', 'development', 'staging', 'testing', 'production', 'global']
 EXTS = ['ini', 'toml', 'yaml', 'json', 'py', 'env']
 WRITERS = ['ini', 'toml', 'yaml', 'json', 'py', 'redis', 'vault', 'env']
 
+ENC = default_settings.ENCODING_FOR_DYNACONF
+
 
 def split_vars(_vars):
     """Splits values like foo=bar=zaz in {'foo': 'bar=zaz'}"""
@@ -56,18 +58,18 @@ def split_vars(_vars):
     } if _vars else {}
 
 
-def read(*names, **kwargs):
+def read_file_in_root_directory(*names, **kwargs):
     """Read a file."""
     return io.open(
         os.path.join(os.path.dirname(__file__), *names),
-        encoding=kwargs.get('encoding', 'utf8')
+        encoding=kwargs.get('encoding', 'utf-8')
     ).read().strip()
 
 
 def print_version(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    click.echo(read('VERSION'))
+    click.echo(read_file_in_root_directory('VERSION'))
     ctx.exit()
 
 
@@ -221,12 +223,14 @@ def init(fileformat, path, env, _vars, _secrets, wg, y):
         ignore_line = ".secrets.*"
         comment = "\n# Ignore dynaconf secret files\n"
         if not gitignore_path.exists():
-            with open(str(gitignore_path), 'w') as f:
+            with io.open(str(gitignore_path), 'w', encoding=ENC) as f:
                 f.writelines([comment, ignore_line, '\n'])
         else:
-            existing = ignore_line in open(str(gitignore_path)).read()
+            existing = ignore_line in io.open(
+                str(gitignore_path), encoding=ENC
+            ).read()
             if not existing:  # pragma: no cover
-                with open(str(gitignore_path), 'a+') as f:
+                with io.open(str(gitignore_path), 'a+', encoding=ENC) as f:
                     f.writelines(
                         [comment, ignore_line, '\n']
                     )

--- a/dynaconf/default_settings.py
+++ b/dynaconf/default_settings.py
@@ -81,6 +81,10 @@ DEFAULT_ENV_FOR_DYNACONF = get('DEFAULT_ENV_FOR_DYNACONF', 'DEFAULT')
 # This namespace is used for files and also envvars
 GLOBAL_ENV_FOR_DYNACONF = get('GLOBAL_ENV_FOR_DYNACONF', 'DYNACONF')
 
+
+# The default encoding to open settings files
+ENCODING_FOR_DYNACONF = get('ENCODING_FOR_DYNACONF', 'utf-8')
+
 # The env var specifying settings module
 ENVVAR_FOR_DYNACONF = get('ENVVAR_FOR_DYNACONF',
                           'SETTINGS_MODULE_FOR_DYNACONF')

--- a/dynaconf/loaders/base.py
+++ b/dynaconf/loaders/base.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import io
 from dynaconf.utils.files import find_file
 from dynaconf.utils import raw_logger
 
@@ -83,7 +84,12 @@ class BaseLoader(object):
             if source_file.endswith(self.extensions):  # pragma: no cover
                 try:
                     source_data = self.file_reader(
-                        open(find_file(source_file))
+                        io.open(
+                            find_file(source_file),
+                            encoding=self.obj.get(
+                                'ENCODING_FOR_DYNACONF', 'utf-8'
+                            )
+                        )
                     )
                     self.obj.logger.debug('{}_loader: {}'.format(
                         self.identifier, source_file))

--- a/dynaconf/loaders/ini_loader.py
+++ b/dynaconf/loaders/ini_loader.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+import io
+from dynaconf import default_settings
 from dynaconf.loaders.base import BaseLoader
 from dynaconf.constants import INI_EXTENSIONS
 from dynaconf.utils import dictmerge
@@ -43,7 +45,12 @@ def write(settings_path, settings_data, merge=True):
     """
     if settings_path.exists() and merge:  # pragma: no cover
         settings_data = dictmerge(
-            ConfigObj(open(str(settings_path))).dict(),
+            ConfigObj(
+                io.open(
+                    str(settings_path),
+                    encoding=default_settings.ENCODING_FOR_DYNACONF
+                )
+            ).dict(),
             settings_data
         )
     new = ConfigObj()

--- a/dynaconf/loaders/json_loader.py
+++ b/dynaconf/loaders/json_loader.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+import io
+from dynaconf import default_settings
 from dynaconf.loaders.base import BaseLoader
 from dynaconf.constants import JSON_EXTENSIONS
 from dynaconf.utils import dictmerge
@@ -34,9 +36,22 @@ def write(settings_path, settings_data, merge=True):
     :param settings_data: a dictionary with data
     :param merge: boolean if existing file should be merged with new data
     """
+
     if settings_path.exists() and merge:  # pragma: no cover
         settings_data = dictmerge(
-            json.load(open(str(settings_path))),
+            json.load(
+                io.open(
+                    str(settings_path),
+                    encoding=default_settings.ENCODING_FOR_DYNACONF
+                )
+            ),
             settings_data
         )
-    json.dump(settings_data, open(str(settings_path), 'w'))
+
+    json.dump(
+        settings_data,
+        io.open(
+            str(settings_path), 'w',
+            encoding=default_settings.ENCODING_FOR_DYNACONF
+        )
+    )

--- a/dynaconf/loaders/py_loader.py
+++ b/dynaconf/loaders/py_loader.py
@@ -1,3 +1,4 @@
+import io
 import os
 import errno
 import types
@@ -59,7 +60,10 @@ def import_from_filename(filename, silent=False):  # pragma: no cover
     mod.__file__ = filename
     mod._is_error = False
     try:
-        with open(find_file(filename)) as config_file:
+        with io.open(
+            find_file(filename),
+            encoding=default_settings.ENCODING_FOR_DYNACONF
+        ) as config_file:
             exec(
                 compile(config_file.read(), filename, 'exec'),
                 mod.__dict__
@@ -89,7 +93,10 @@ def write(settings_path, settings_data, merge=True):
             existing,
             settings_data
         )
-    with open(str(settings_path), 'w') as f:
+    with io.open(
+        str(settings_path), 'w',
+        encoding=default_settings.ENCODING_FOR_DYNACONF
+    ) as f:
         f.writelines(
             ["{} = {}\n".format(k.upper(), repr(v))
              for k, v in settings_data.items()]

--- a/dynaconf/loaders/toml_loader.py
+++ b/dynaconf/loaders/toml_loader.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+import io
+from dynaconf import default_settings
 from dynaconf.loaders.base import BaseLoader
 from dynaconf.constants import TOML_EXTENSIONS
 from dynaconf.utils import dictmerge
@@ -43,7 +45,19 @@ def write(settings_path, settings_data, merge=True):
     """
     if settings_path.exists() and merge:  # pragma: no cover
         settings_data = dictmerge(
-            toml.load(open(str(settings_path))),
+            toml.load(
+                io.open(
+                    str(settings_path),
+                    encoding=default_settings.ENCODING_FOR_DYNACONF
+                )
+            ),
             settings_data
         )
-    toml.dump(settings_data, open(str(settings_path), 'w'))
+
+    toml.dump(
+        settings_data,
+        io.open(
+            str(settings_path), 'w',
+            encoding=default_settings.ENCODING_FOR_DYNACONF
+        )
+    )

--- a/dynaconf/loaders/yaml_loader.py
+++ b/dynaconf/loaders/yaml_loader.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+import io
+from dynaconf import default_settings
 from dynaconf.loaders.base import BaseLoader
 from dynaconf.constants import YAML_EXTENSIONS
 from dynaconf.utils import dictmerge
@@ -43,7 +45,19 @@ def write(settings_path, settings_data, merge=True):
     """
     if settings_path.exists() and merge:  # pragma: no cover
         settings_data = dictmerge(
-            yaml.load(open(str(settings_path))),
+            yaml.load(
+                io.open(
+                    str(settings_path),
+                    encoding=default_settings.ENCODING_FOR_DYNACONF
+                )
+            ),
             settings_data
         )
-    yaml.dump(settings_data, open(str(settings_path), 'w'))
+
+    yaml.dump(
+        settings_data,
+        io.open(
+            str(settings_path), 'w',
+            encoding=default_settings.ENCODING_FOR_DYNACONF
+        )
+    )

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import os
 import logging
 

--- a/example/common-encoding/.env
+++ b/example/common-encoding/.env
@@ -1,0 +1,5 @@
+# Extra values can be exported here using DYNACONF_ prefix
+# also possible to export as traditional envvar
+# export DYNACONF_EXTRA_VALUE='Value defined in .env'
+DYNACONF_EXTRA_VALUE='Value defined in .env'
+ENCODING_FOR_DYNACONF="cp1252"

--- a/example/common-encoding/.secrets.toml
+++ b/example/common-encoding/.secrets.toml
@@ -1,0 +1,7 @@
+[default]
+encoded_variable="This has accents like ç and ã é ó ú just to test encoding à"
+password = 'SuperSecret'
+[development]
+password = 'SuperSecretDev'
+[production]
+password = 'SuperSecretProd'

--- a/example/common-encoding/program.py
+++ b/example/common-encoding/program.py
@@ -1,0 +1,162 @@
+# Take as example a program which connects to a database
+import io
+import os
+
+
+def connect(server, port, username, password):
+    """This function might be something coming from your ORM"""
+    print('-' * 79)
+    print('Connecting to: {}'.format(server))
+    print('At port: {}'.format(port))
+    print('Using username: {}'.format(username))
+    print('Using password: {}'.format(password))
+    print('-' * 79)
+    # imagine it connects here...
+
+
+# The `connect` function needs to take the server, username and value
+# and those values must be read from settings.toml config file
+
+# The `password` is sensitive so it comes from .secrets.toml file
+# or even better it may come from vaultproject.io
+
+# Dynaconf takes care of it!
+
+from dynaconf import settings  # noqa
+
+print(settings.dynaconf_banner)
+
+print('#' * 79)
+print('\n* The settings are defined in .toml files\n')
+print('$ cat settings.toml')
+print(
+    io.open(
+        'settings.toml',
+        encoding=os.environ.get('ENCODING_FOR_DYNACONF')
+    ).read()
+)
+print('$ cat .secrets.toml')
+print(
+    io.open(
+        '.secrets.toml',
+        encoding=os.environ.get('ENCODING_FOR_DYNACONF')
+    ).read()
+)
+
+print('#' * 79)
+print('\n* Acessing settings defined in .toml files\n')
+print('By default dynaconf will always work in "development" env')
+print('Take a look at settings.toml and .secrets.toml')
+connect(settings.SERVER, settings.PORT, settings.USERNAME, settings.PASSWORD)
+assert settings.SERVER == 'devserver.com'
+assert settings.PORT == 5555
+assert settings.USERNAME == 'admin'
+assert settings.PASSWORD == 'SuperSecretDev'
+
+print('#' * 79)
+print('\n* Working on a different environment\n')
+print('To switch the env export the ENV_FOR_DYNACONF variable')
+print('$ export ENV_FOR_DYNACONF=production')
+print('Now reading settings from PRODUCTION env:')
+# this next line is not needed in your program, it is the same as `export ENV_FOR_DYNACONF..`
+import os; os.environ['ENV_FOR_DYNACONF'] = 'production'; settings.reload()  # noqa
+connect(settings.SERVER, settings.PORT, settings.USERNAME, settings.PASSWORD)
+assert settings.SERVER == 'prodserver.com'
+assert settings.PORT == 5555
+assert settings.USERNAME == 'admin'
+assert settings.PASSWORD == 'SuperSecretProd'
+
+print('#' * 79)
+print('\n* Switching environments\n')
+print('We can easily switch to staging env')
+print('$ export ENV_FOR_DYNACONF=staging')
+# this next line is not needed in your program, it is the same as `export ENV_FOR_DYNACONF..`
+os.environ['ENV_FOR_DYNACONF'] = 'staging'; settings.reload()  # noqa
+connect(settings.SERVER, settings.PORT, settings.USERNAME, settings.PASSWORD)
+assert settings.SERVER == 'stagserver.com'
+assert settings.PORT == 5555
+assert settings.USERNAME == 'admin'
+assert settings.PASSWORD == 'SuperSecret'  # will use the [default]
+
+
+print('#' * 79)
+print('\n* Environments and Custom Environments\n')
+print('Dynaconf works with 4 predefined envs:')
+print('  [development](the default), [production], [staging], [testing]')
+print('There is also the pseudo envs')
+print('  [default](default values) and [global](overrides every value)')
+print('It is also possible to define custom envs')
+print('$ export ENV_FOR_DYNACONF=mycustomenv')
+# this next line is not needed in your program, it is the same as `export ENV_FOR_DYNACONF..`
+os.environ['ENV_FOR_DYNACONF'] = 'mycustomenv'; settings.reload()  # noqa
+connect(settings.SERVER, settings.PORT, settings.USERNAME, settings.PASSWORD)
+assert settings.SERVER == 'customserver.com'
+assert settings.PORT == 5555
+assert settings.USERNAME == 'admin'
+assert settings.PASSWORD == 'SuperSecret'  # will use the [default]
+
+print('#' * 79)
+print('\n* Default and Global settings\n')
+print('The env [global] is to override values defined in any other env')
+print('It means a value in [global] will always take high precedence')
+print('To override any value in [global] just put the value in .toml file')
+print('Or via envvars export a value with DYNACONF_ prefix')
+print('$ export DYNACONF_USERNAME="NewUsername"')
+print('You can also put the value in .env file"')
+# this next line is not needed in your program, it is the same as `export DYNACONF_USERNAME..`
+os.environ['DYNACONF_USERNAME'] = 'NewUsername'; settings.reload()  # noqa
+connect(settings.SERVER, settings.PORT, settings.USERNAME, settings.PASSWORD)
+print('settings.EXTRA_VALUE = ', settings.EXTRA_VALUE)
+assert settings.SERVER == 'customserver.com'
+assert settings.PORT == 5555
+assert settings.USERNAME == 'NewUsername'
+assert settings.PASSWORD == 'SuperSecret'  # will use the [default]
+assert settings.EXTRA_VALUE == 'Value defined in .env'
+
+print('#' * 79)
+print('\n* Using environment variables at program call\n')
+print('Another common pattern is defining the value in the program call')
+print('$ DYNACONF_USERNAME=YetAnotherUser python program.py')
+# this next line is not needed in your program, it is the same as `export DYNACONF_USERNAME..`
+os.environ['DYNACONF_USERNAME'] = 'YetAnotherUser'; settings.reload()  # noqa
+connect(settings.SERVER, settings.PORT, settings.USERNAME, settings.PASSWORD)
+assert settings.SERVER == 'customserver.com'
+assert settings.PORT == 5555
+assert settings.USERNAME == 'YetAnotherUser'
+assert settings.PASSWORD == 'SuperSecret'  # will use the [default]
+
+
+print('#' * 79)
+print('\n* Type definitions for environment variables\n')
+print('Note that the PORT variable must be integer')
+print('And envvars are by default string typed')
+print('Dynaconf allows type definition on exporting an envvar')
+print('$ export DYNACONF_PORT="@int 8888"')
+# this next line is not needed in your program, it is the same as `export DYNACONF_USERNAME..`
+os.environ['DYNACONF_PORT'] = '@int 8888'; settings.reload()  # noqa
+connect(settings.SERVER, settings.PORT, settings.USERNAME, settings.PASSWORD)
+assert settings.SERVER == 'customserver.com'
+assert settings.PORT == 8888
+assert settings.USERNAME == 'YetAnotherUser'
+assert settings.PASSWORD == 'SuperSecret'  # will use the [default]
+print('DONT WORRY: if you dont like the `@type` strategy you can disable it')
+print('and perform the explicit cast when reading')
+print('>>> connect(..., settings.as_int("PORT"), ...)')
+print('types: @int|.as_int, @float|.as_float, @bool|.as_bool and @json|.as_json')
+
+print('#' * 79)
+print('\n* There is more!\n')
+print('Dynaconf can switch environments programatically with context managers.')
+print('Dynaconf has extensions for Flask and Django.')
+print('Dynaconf can read values from yaml, ini, json and py files.')
+print('Dynaconf can load sensitive values from vaultproject.io.')
+print('Dynaconf can load dynamic fresh values from Redis server (useful for feature flagging).')
+print('#' * 79)
+print(settings.dynaconf_banner)
+print('Learn more at http://github.com/rochacbruno/dynaconf')
+
+
+with settings.using_env('testing'):
+    assert settings.SERVER == 'testserver.com'
+
+assert settings.SERVER == 'customserver.com'

--- a/example/common-encoding/settings.toml
+++ b/example/common-encoding/settings.toml
@@ -1,0 +1,15 @@
+[default]
+encoded_variable="This has accents like ç and ã é ó ú just to test encoding à"
+port = 5555
+[development]
+server = 'devserver.com'
+[production]
+server = 'prodserver.com'
+[staging]
+server = 'stagserver.com'
+[testing]
+server = 'testserver.com'
+[mycustomenv]
+server = 'customserver.com'
+[global]
+username = 'admin'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
+import io
 import os
 import pytest
 from pathlib import Path
 from click.testing import CliRunner
-from dynaconf.cli import main, EXTS, WRITERS, ENVS, read
+from dynaconf import default_settings
+from dynaconf.cli import main, EXTS, WRITERS, ENVS, read_file_in_root_directory
 from dotenv import cli as dotenv_cli
 
 
@@ -16,7 +18,7 @@ def run(cmd):
 
 
 def test_version():
-    assert read('VERSION') in run(['--version'])
+    assert read_file_in_root_directory('VERSION') in run(['--version'])
 
 
 def test_help():
@@ -49,7 +51,11 @@ def test_init(fileformat):
 
     sets = Path(path)
     assert sets.exists() is True
-    assert 'bruno' in open(str(sets)).read()
+
+    assert 'bruno' in io.open(
+        str(sets),
+        encoding=default_settings.ENCODING_FOR_DYNACONF
+    ).read()
 
     if fileformat != 'env':
         os.remove(str(sets))
@@ -59,7 +65,10 @@ def test_init(fileformat):
     if secs_path:
         secs = Path('.secrets.{}'.format(fileformat))
         assert secs.exists() is True
-        assert 'TOKEN' in open(str(secs)).read()
+        assert 'TOKEN' in io.open(
+            str(secs),
+            encoding=default_settings.ENCODING_FOR_DYNACONF
+        ).read()
         os.remove(str(secs))
 
 
@@ -85,17 +94,26 @@ def test_init_with_path(fileformat, tmpdir):
 
     sets = Path(str(path))
     assert sets.exists() is True
-    assert 'value for development' in open(str(sets)).read()
+    assert 'value for development' in io.open(
+        str(sets),
+        encoding=default_settings.ENCODING_FOR_DYNACONF
+    ).read()
 
     if secs_path:
         secs = Path(str(secs_path))
         assert secs.exists() is True
-        assert 'secret for' in open(str(secs)).read()
+        assert 'secret for' in io.open(
+            str(secs),
+            encoding=default_settings.ENCODING_FOR_DYNACONF
+        ).read()
 
     if fileformat != 'env':
         gign = Path(str(tmpdir.join('.gitignore')))
         assert gign.exists() is True
-        assert ".secrets.*" in open(str(gign)).read()
+        assert ".secrets.*" in io.open(
+            str(gign),
+            encoding=default_settings.ENCODING_FOR_DYNACONF
+        ).read()
 
 
 def test_list():
@@ -175,12 +193,24 @@ def test_write(writer, env, onlydir, tmpdir):
     )
     if writer != 'env':
         assert "Data successful written to {}".format(settingspath) in result
-        assert "TESTVALUE" in open(str(settingspath)).read()
-        assert "SECRETVALUE" in open(str(secretfile)).read()
+        assert "TESTVALUE" in io.open(
+            str(settingspath),
+            encoding=default_settings.ENCODING_FOR_DYNACONF
+        ).read()
+        assert "SECRETVALUE" in io.open(
+            str(secretfile),
+            encoding=default_settings.ENCODING_FOR_DYNACONF
+        ).read()
     else:
         assert "Data successful written to {}".format(env_file) in result
-        assert "TESTVALUE" in open(str(env_file)).read()
-        assert "SECRETVALUE" in open(str(env_file)).read()
+        assert "TESTVALUE" in io.open(
+            str(env_file),
+            encoding=default_settings.ENCODING_FOR_DYNACONF
+        ).read()
+        assert "SECRETVALUE" in io.open(
+            str(env_file),
+            encoding=default_settings.ENCODING_FOR_DYNACONF
+        ).read()
 
 
 @pytest.mark.parametrize("path", ('.env', './.env'))
@@ -199,8 +229,14 @@ def test_write_dotenv(path, tmpdir):
     )
 
     assert "Data successful written to {}".format(env_file) in result
-    assert "TESTVALUE" in open(str(env_file)).read()
-    assert "SECRETVALUE" in open(str(env_file)).read()
+    assert "TESTVALUE" in io.open(
+        str(env_file),
+        encoding=default_settings.ENCODING_FOR_DYNACONF
+    ).read()
+    assert "SECRETVALUE" in io.open(
+        str(env_file),
+        encoding=default_settings.ENCODING_FOR_DYNACONF
+    ).read()
 
 
 VALIDATION = """

--- a/tests/test_py_loader.py
+++ b/tests/test_py_loader.py
@@ -1,11 +1,16 @@
+import io
 import os
+from dynaconf import default_settings
 from dynaconf.utils import DynaconfDict
 from dynaconf.loaders.py_loader import load
 
 
 def test_py_loader():
     settings = DynaconfDict(_no_project_root=True)
-    with open('dummy_module.py', 'w') as f:
+    with io.open(
+        'dummy_module.py', 'w',
+        encoding=default_settings.ENCODING_FOR_DYNACONF
+    ) as f:
         f.write('FOO = "bar"')
 
     load(settings, 'dummy_module')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 # coding: utf-8
+import io
 import os
 import pytest
 import tempfile
+from dynaconf import default_settings
 from dynaconf.utils.parse_conf import unparse_conf_data, parse_conf_data
 from dynaconf.utils.files import find_file
 
@@ -58,7 +60,10 @@ def test_find_file():
 
     # now place a .env file a few levels up and make sure it's found
     filename = os.path.join(child1, '.env')
-    with open(filename, 'w') as f:
+    with io.open(
+        filename, 'w',
+        encoding=default_settings.ENCODING_FOR_DYNACONF
+    ) as f:
         f.write("TEST=test\n")
     assert find_file(usecwd=True) == filename
 


### PR DESCRIPTION
> IMPORTANT: Dynaconf by default reads settings files using `utf-8` encoding, if you have settings files written in other encoding please set `ENCODING_FOR_DYNACONF` environment variable see more in [configuration](https://dynaconf.readthedocs.io/en/latest/guides/configuration.html)

```
export ENCODING_FOR_DYNACONF="cp1252"
```