### PR TITLE
Allow dot-traversal access to nested dictionaries.

### DIFF
--- a/docs/guides/accessing_values.md
+++ b/docs/guides/accessing_values.md
@@ -41,6 +41,20 @@ settings.get('TIMEOUT', 300)
 
 > Returns the default (300) if not defined
 
+Using dotted-path lookup
+
+```python
+settings.get('AUTH.USER', 'anonymous')
+```
+
+> Returns the default ('anonymous') if not defined
+
+Explicitly disabling dotted-path lookup
+
+```python
+settings.get('AUTH.USER', dotted_lookup=False)
+```
+
 ## Forcing type casting
 
 ```python

--- a/example/full_example.py
+++ b/example/full_example.py
@@ -54,4 +54,7 @@ print(settings.get('FOO', default='bar'))
 print("\nThe host for default :")
 print(settings.HOSTNAME)
 
+print("\nDotted path lookup value :")
+print(settings('ADICT.KEY'))
+
 print(settings.WORKS)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -176,3 +176,26 @@ def test_set(settings):
 def test_exists(settings):
     settings.set('BOOK', 'TAOCP')
     assert settings.exists('BOOK') == True
+
+
+def test_dotted_traversal_access(settings):
+    settings.set('PARAMS', {'PASSWORD': 'secret', 'SSL': {'CONTEXT': 'SECURE'}})
+    assert settings.get('PARAMS') == {
+        'PASSWORD': 'secret',
+        'SSL': {
+            'CONTEXT': 'SECURE'
+        }
+    }
+
+    assert settings('PARAMS.PASSWORD') == 'secret'
+    assert settings('PARAMS.TOKEN.IMAGINARY', 1234) == 1234
+    assert settings('IMAGINARY_KEY') is None
+
+    assert settings['PARAMS.PASSWORD'] == 'secret'
+
+    # Dotted traversal should not work for dictionary-like key access.
+    with pytest.raises(KeyError):
+        settings['PARAMS.DOESNOTEXIST']
+
+    # Disable dot-traversal on a per-call basis.
+    assert settings('PARAMS.PASSWORD', dotted_lookup=False) is None


### PR DESCRIPTION
A simple memoized recursion has been added to `get()` if the key contains at least one dot.

The caller can choose to opt-out of this behaviour by specifying the `dotted_lookup` argument:

```python
settings('AUTH.USERNAME', dotted_lookup=False)
```

While the performance impact of this has not been quantified, the net impact in any real-world application should be minimal due to typical nesting levels, and the fact that we overwrite the memoized portion of the dotted-key lookup on each iteration.

Perhaps at some point a suite of benchmarks can be added, to which the impact of dotted-key lookups can be analyzed further.

- Avoids regressions [✓]
- Can be opted-out on a per-call basis [✓]
- Minimal performance impact [✓]
- Documented [✓]
- Tested [✓]
- Examples added [✓]

I tried to find all of the bits & pieces of docs and examples to make sure that this feature was correctly described and in the style of the project, but I wouldn't be surprised if I missed something. Please let me know!

Also: 

Closes rochacbruno/dynaconf#84