### PR TITLE
Tox and TravisCI enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,28 +57,31 @@ jobs:
         - "pip install --upgrade -r requirements_dev.txt"
       script: make test
 
-    # PYYAML IS BROKEN in 3.7 dev
-    # - stage: Python 3.7
-    #   language: python
-    #   python: "3.7-dev"
-    #   env:
-    #     - DYNACONF_SETTINGS=dynaconf.test_settings
-    #     - DOTENV_PATH_FOR_DYNACONF=/home/travis/build/rochacbruno/dynaconf/.env
-    #     - DYNATRAVIS_ENV_BOOLEAN='@bool true'
-    #     - DYNATRAVIS_ENV_INT='@int 42'
-    #     - DYNATRAVIS_ENV_FLOAT='@float 42.2'
-    #     - DYNATRAVIS_ENV_LIST='@json ["dyna", "conf"]'
-    #     # - DYNATRAVIS_ENV_DICT='@json {"dyna": "conf"}' how to fix this?
-    #     - DYNATRAVIS_ENV_DICT='@json {}'
-    #     - DYNATRAVIS_ENV_PURE_INT=42
-    #     - DYNATRAVIS_ENV_STR_INT="'42'"
-    #     - OTHER_TESTING='@bool yes'
-    #     - OTHER_ENABLED=true
-    #     - OTHER_DISABLED=false
-    #   install:
-    #     - "pip install --upgrade pip"
-    #     - "pip install --upgrade -r requirements_dev.txt"
-    #   script: make test
+    - stage: Python 3.7
+      language: python
+      python: "3.7"
+      dist: xenial
+      sudo: yes
+      env:
+        - DYNACONF_SETTINGS=dynaconf.test_settings
+        - DOTENV_PATH_FOR_DYNACONF=/home/travis/build/rochacbruno/dynaconf/.env
+        - DYNATRAVIS_ENV_BOOLEAN='@bool true'
+        - DYNATRAVIS_ENV_INT='@int 42'
+        - DYNATRAVIS_ENV_FLOAT='@float 42.2'
+        - DYNATRAVIS_ENV_LIST='@json ["dyna", "conf"]'
+        # - DYNATRAVIS_ENV_DICT='@json {"dyna": "conf"}' how to fix this?
+        - DYNATRAVIS_ENV_DICT='@json {}'
+        - DYNATRAVIS_ENV_PURE_INT=42
+        - DYNATRAVIS_ENV_STR_INT="'42'"
+        - OTHER_TESTING='@bool yes'
+        - OTHER_ENABLED=true
+        - OTHER_DISABLED=false
+      before_script:
+        - sleep 5
+      install:
+        - "pip install --upgrade pip"
+        - "pip install --upgrade -r requirements_dev.txt"
+      script: make test
 
     - stage: Python 3.6 with coverage
       language: python

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36
+envlist = py34,py35,py36,py37
 whitelist_externals=make
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,6 @@ whitelist_externals=
     cd
     python
 commands =
-    py.test --boxed -v --cov=dynaconf -l --tb=short --maxfail=1 tests/
+    py.test --boxed -v --cov=dynaconf -l --tb=short --maxfail=1 {posargs}
     ; make test_examples
 


### PR DESCRIPTION
## Summary
These are a few test-only changes that I've been running locally for a little while now, and I thought I'd contribute them back upstream, if they're desired.

## Details
- Enables Python 3.7 testing on TravisCI via the usage of `dist: xenial`.
- Enables Python 3.7 in `tox.ini` environment list.
-  Update `py.test` command in `tox.ini` to allow passing positional arguments.

    The basic, default functionality of running `tox` remains unchanged. You are now, however, able to pass positional arguments to `py.test` at invocation time. For example:

    ```bash
    tox -- -x --pdb tests/test_basic.py
    ```

    Which will pass all input after the `--` separator (which is used to signify the end of possible options to `tox`) down to the `py.test` command in the `{posargs}` location, as defined in `tox.ini`.

