### PR TITLE
Allow dotted-path based setting of configuration key/value pairs.

### DIFF
--- a/example/full_example.py
+++ b/example/full_example.py
@@ -58,3 +58,6 @@ print("\nDotted path lookup value :")
 print(settings('ADICT.KEY'))
 
 print(settings.WORKS)
+
+print("\nDotted path set value :")
+print(settings.set('ONE.TWO', 'value'))


### PR DESCRIPTION
## Summary

To mirror the functionality added in #93, the ability to set nested structures has been added in this PR.

## Examples

You can set a value with an arbitrary number of nested keys, separated by dots:

```python
settings.set('nested_1.nested_2.nested_3.nested_4', 'secret')
```

And accessing the keys/values with dotted-path lookup behaves as expected:

```python
print(settings.NESTED_1.NESTED_2.NESTED_3.to_dict())
```

If for some reason you didn't want to have a key parsed into nested structures delimited by dots and just wanted a key of "foo.bar", you can disable the parsing with:

```python
settings.set('nested_1.nested_2.nested_3.nested_4',
                    'secret',
                    dotted_lookup=False)
```

And accessing keys that don't exist will raise `KeyError`:

```python
# Raises KeyError due to NESTED_5 not existing
settings.NESTED_1.NESTED_5
```

Tests have been added, and it functions with the merge functionality introduced in #88.

## References

Closes #96.