### PR TITLE
fixed infinite recursion caused by copy()

### DIFF
--- a/dynaconf/utils/boxing.py
+++ b/dynaconf/utils/boxing.py
@@ -21,6 +21,12 @@ class DynaBox(Box):
             n_item = item.lower() if item.isupper() else item.upper()
             return super(DynaBox, self).__getitem__(n_item, *args, **kwargs)
 
+    def __copy__():
+        return self.__class__(super(Box, self).copy())
+
+    def copy():
+        return self.__class__(super(Box, self).copy())
+
     def get(self, item, default=None, *args, **kwargs):
         value = super(DynaBox, self).get(item, default, *args, **kwargs)
         if value is None or value == default:


### PR DESCRIPTION
`DynaBox` was previously inheriting `Box`'s `__copy__()` and `copy()` methods. These methods are here from class `Box`:
```
def copy(self):
    return self.__class__(super(self.__class__, self).copy())

def __copy__(self):
    return self.__class__(super(self.__class__, self).copy())
```
Due to the way super works and is coded in `Box` this causes infinite recursion whenever an instance of `DynaBox` calls `copy`. This happens for instance when Django reads a settings stored as a table in `settings.toml`. It imports it as a DynaBox but expects it to have the duck typing behavior of a dictionary (and thus the copy operation). So the fix is to override these two methods and specify specifically to call `Box`'s implementation. Alternatively `super(dict, self).copy()` works too but I thought it makes more sense to reference the implementation that DyanBox is inheriting from directly.