### PR TITLE
Add support for environments in Vault

### DIFF
--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -422,7 +422,9 @@ def write(to, _vars, _secrets, path, env, y):
 
     else:  # pragma: no cover
         # lets write to external source
-        loader.write(settings, _vars, **_secrets)
+        with settings.using_env(env):
+            # make sure we're in the correct environment
+            loader.write(settings, _vars, **_secrets)
         click.echo('Data successful written to {}'.format(to))
 
 


### PR DESCRIPTION
We want to be able to use a single Vault server for multiple environments. Currently, Dynaconf does not support multiple environments in Vault.
This PR adds the working environment into the path, so that the same Vault server can be used for multiple environments.

- Converted `os.path.join()` to `'/'.join()` as Vault only uses `/` and this would cause Dynaconf on Windows to provide an incorrect path to Vault.