### PR TITLE
Fix exponential slow down when loader is run multiple times

### DIFF
--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -17,6 +17,8 @@ def object_merge(old, new):
     Recursively merge two data structures
     """
     if isinstance(old, list) and isinstance(new, list):
+        if old == new:
+            return
         for item in old[::-1]:
             new.insert(0, item)
     if isinstance(old, dict) and isinstance(new, dict):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -188,6 +188,11 @@ def test_set_merge(settings):
         ]
     }
 
+def test_merge_shortcut(settings):
+    settings.set("MERGE_ENABLED_FOR_DYNACONF", True)
+    settings.set("MERGE_KEY", ["item1"])
+    settings.set("MERGE_KEY", ["item1"])
+    assert settings.MERGE_KEY == ["item1"]
 
 def test_exists(settings):
     settings.set('BOOK', 'TAOCP')


### PR DESCRIPTION
* When using context managers, the loader is invoked each time.
  This was slowing down in an exponential manner each time the it was run.
  The eventual cause of this was down to an attribute being used as a list.
  The object merge dutifully tried to expand this item out again and again
  even in the case that the list was a single item, resulting in [item],
  becoming [item, item]. The next time the merge was run, this process was
  run again, but for each item in the list. In this particular instance
  the list was identical, it meant that the list grew exponentially.
* This fix is a short optimization that checks to see if the old list
  is identical to the new list. In which case, there is no merge to complete
  so we simply return.