### PR TITLE
GH-111: Fix MERGE_ENABLED merging default settings with themselves

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -261,7 +261,8 @@ class Settings(object):
             return default
 
         if (
-            (fresh or self._fresh or key in self.FRESH_VARS_FOR_DYNACONF) and
+            (fresh or self._fresh or
+                key in getattr(self, 'FRESH_VARS_FOR_DYNACONF', ())) and
             key not in dir(default_settings)
         ):
             self.unset(key)

--- a/dynaconf/loaders/__init__.py
+++ b/dynaconf/loaders/__init__.py
@@ -22,9 +22,10 @@ def default_loader(obj, defaults=None):
     all_keys = list(default_settings_values.keys()) + list(defaults.keys())
 
     for key in all_keys:
-        value = defaults.get(key, default_settings_values.get(key))
-        obj.logger.debug("default_loader: loading: %s:%s", key, value)
-        obj.set(key, value)
+        if not obj.exists(key):
+            value = defaults.get(key, default_settings_values.get(key))
+            obj.logger.debug("default_loader: loading: %s:%s", key, value)
+            obj.set(key, value)
 
     # start dotenv to get default env vars from there
     # check overrides in env vars


### PR DESCRIPTION
This fixes a bug where the default settings passed to the LazySettings constructor are merged with themselves when MERGE_ENABLED is true. This caused a conflict with django_dynaconf, which passes all of its settings as defaults. It did not produce immediate errors when loading django_dynaconf in INSTALLED_APPS because dynaconf was activated after application loading, but activating before application loading produces the error seen in #111.

The fix is to check for the existence of a setting before calling set() in default_loader.