### PR TITLE
Fix #117 add support for extra secrets file (like for jenkins CI)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ test_examples:
 	@cd example/envs;pwd;python app.py
 	@cd example/custom_loader;pwd;python app.py
 	@cd example/get_fresh;pwd;python app.py
+	@cd example/jenkins_secrets_file;pwd;python app.py
+	@cd example/specific_settings_modules;pwd;python app.py
 	@cd example/django_example/;pwd;python manage.py test
 	@cd example/project_root/;pwd;rm -rf /tmp/dynaconf_project_root_test/settings.py;mkdir -p /tmp/dynaconf_project_root_test/;echo "MESSAGE = 'Hello from tmp'" > /tmp/dynaconf_project_root_test/settings.py;python app.py;rm -rf /tmp/dynaconf_project_root_test/
 	@cd example/settings_module/;pwd;rm -rf /tmp/settings_module_test/settings.py;mkdir -p /tmp/settings_module_test/;echo "MESSAGE = 'Hello from tmp'" > /tmp/settings_module_test/settings.py;python app.py;rm -rf /tmp/settings_module_test/

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -59,6 +59,8 @@ Dynaconf can be configured through variables suffixed with `_FOR_DYNACONF` those
 +---------------------+---------+--------------------------------------------------+----------------------------------------+--------------------------------------------------------------+
 | COMMENTJSON_ENABLED | bool    | Enable comments in json files                    | false  (req:`pip install commentjson`) | COMMENTJSON_ENABLED_FOR_DYNACONF=true                        |
 +---------------------+---------+--------------------------------------------------+----------------------------------------+--------------------------------------------------------------+
+| SECRETS             | str     | Path to aditional secrets file to be loaded      | None                                   | SECRETS_FOR_DYNACONF=/var/jenkins/settings_ci.toml           |
++---------------------+---------+--------------------------------------------------+----------------------------------------+--------------------------------------------------------------+
 ```
 
 ```eval_rst

--- a/dynaconf/default_settings.py
+++ b/dynaconf/default_settings.py
@@ -165,3 +165,9 @@ YAML_LOADER_FOR_DYNACONF = get('YAML_LOADER_FOR_DYNACONF', 'full_load')
 COMMENTJSON_ENABLED_FOR_DYNACONF = get(
     'COMMENTJSON_ENABLED_FOR_DYNACONF', False
 )
+
+# Extra file, or list of files where to look for secrets
+# useful for CI environment like jenkins
+# where you can export this variable pointing to a local
+# absolute path of the secrets file.
+SECRETS_FOR_DYNACONF = get('SECRETS_FOR_DYNACONF', None)

--- a/dynaconf/loaders/__init__.py
+++ b/dynaconf/loaders/__init__.py
@@ -15,7 +15,7 @@ def default_loader(obj, defaults=None):
     default_settings_values = {
         key: value
         for key, value
-        in default_settings.__dict__.items()
+        in default_settings.__dict__.items()  # noqa
         if key.isupper()
     }
 
@@ -56,12 +56,19 @@ def settings_loader(obj, settings_module=None, env=None,
         if not settings_module:  # pragma: no cover
             return
 
-        if not isinstance(settings_module, (list, tuple)):
-            files = settings_module.split(',')
+        if isinstance(settings_module, (list, tuple)):
+            files = list(settings_module)
         else:
-            files = [settings_module]
+            files = settings_module.split(',')
     else:
         files = [filename]
+
+    secrets_file = obj.get('SECRETS_FOR_DYNACONF', None)
+    if secrets_file is not None:
+        if isinstance(secrets_file, (list, tuple)):
+            files.extend(secrets_file)
+        else:
+            files.extend(secrets_file.split(','))
 
     obj.logger.debug("Looking for %s", files)
 

--- a/example/jenkins_secrets_file/.env
+++ b/example/jenkins_secrets_file/.env
@@ -1,0 +1,1 @@
+SECRETS_FOR_DYNACONF=jenkins_secrets.toml

--- a/example/jenkins_secrets_file/app.py
+++ b/example/jenkins_secrets_file/app.py
@@ -1,0 +1,7 @@
+from dynaconf import settings
+
+# Assuming this app is running on CI the secret values would be read from
+# jenkins_secrets.toml that was  defined by SECRETS_FOR_DYNACONF envvar
+
+assert settings.USERNAME == 'jenkins'
+assert settings.PASSWORD == 's3cr3t'

--- a/example/jenkins_secrets_file/jenkins_secrets.toml
+++ b/example/jenkins_secrets_file/jenkins_secrets.toml
@@ -1,0 +1,3 @@
+[default]
+username = 'jenkins'
+password = 's3cr3t'

--- a/example/jenkins_secrets_file/settings.toml
+++ b/example/jenkins_secrets_file/settings.toml
@@ -1,0 +1,3 @@
+[default]
+username = 'default_username'
+password = 'blank'

--- a/example/specific_settings_modules/.env
+++ b/example/specific_settings_modules/.env
@@ -1,0 +1,1 @@
+SETTINGS_MODULE_FOR_DYNACONF='first_settings.toml,second_settings.toml,extra_settings.py'

--- a/example/specific_settings_modules/app.py
+++ b/example/specific_settings_modules/app.py
@@ -1,0 +1,5 @@
+from dynaconf import settings
+
+assert settings.FIRST_VAR == 'first_value'
+assert settings.SECOND_VAR == 'second_value'
+assert settings.EXTRA_VAR == 'extra_value'

--- a/example/specific_settings_modules/extra_settings.py
+++ b/example/specific_settings_modules/extra_settings.py
@@ -1,0 +1,1 @@
+EXTRA_VAR = 'extra_value'

--- a/example/specific_settings_modules/first_settings.toml
+++ b/example/specific_settings_modules/first_settings.toml
@@ -1,0 +1,2 @@
+[default]
+first_var = 'first_value'

--- a/example/specific_settings_modules/second_settings.toml
+++ b/example/specific_settings_modules/second_settings.toml
@@ -1,0 +1,2 @@
+[default]
+SECOND_VAR = 'second_value'


### PR DESCRIPTION
Now it is possible to export SECRETS_FOR_DYNACONF and have this
extra point loaded, like in a Jenkins CI you can specify on job.

```yaml
secret_file:
  variable: SECRETS_FOR_DYNACONF
  credentials:
    type: specific_credentials
    value: /path/to/secrets_file.toml{json,ini,yaml,py}

```

That variable can also be a list of paths.

Fix #117 