### PR TITLE
Skip reloading envs for validators that only apply to current_env

### DIFF
--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -100,7 +100,10 @@ class Validator(object):
                 return
 
         # If only using current_env, skip using_env decoration (reload)
-        if len(self.envs) == 1 and self.envs[0] == settings.current_env:
+        if (
+            len(self.envs) == 1 and
+            self.envs[0].upper() == settings.current_env.upper()
+        ):
             self._validate_items(settings, settings.current_env)
             return
 

--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -99,53 +99,62 @@ class Validator(object):
                 # if when is invalid, return canceling validation flow
                 return
 
+        # If only using current_env, skip using_env decoration (reload)
+        if len(self.envs) == 1 and self.envs[0] == settings.current_env:
+            self._validate_items(settings, settings.current_env)
+            return
+
         for env in self.envs:
             with settings.using_env(env):
-                for name in self.names:
-                    exists = settings.exists(name)
+                self._validate_items(settings, env)
 
-                    # is name required but not exists?
-                    if self.must_exist is True and not exists:
-                        raise ValidationError(
-                            '{0} is required in env {1}'.format(
-                                name, env
-                            )
+    def _validate_items(self, settings, env):
+        for name in self.names:
+            exists = settings.exists(name)
+
+            # is name required but not exists?
+            if self.must_exist is True and not exists:
+                raise ValidationError(
+                    '{0} is required in env {1}'.format(
+                        name, env
+                    )
+                )
+            elif self.must_exist is False and exists:
+                raise ValidationError(
+                    '{0} cannot exists in env {1}'.format(
+                        name, env
+                    )
+                )
+
+            # if not exists and not required cancel validation flow
+            if not exists:
+                return
+
+            value = settings[name]
+
+            # is there a callable condition?
+            if self.condition is not None:
+                if not self.condition(value):
+                    raise ValidationError(
+                        '{0} invalid for {1}({2}) '
+                        'in env {3}'.format(
+                            name, self.condition.__name__,
+                            value, env
                         )
-                    elif self.must_exist is False and exists:
-                        raise ValidationError(
-                            '{0} cannot exists in env {1}'.format(
-                                name, env
-                            )
+                    )
+
+            # operations
+            for op_name, op_value in self.operations.items():
+                op_function = getattr(validator_conditions, op_name)
+                if not op_function(value, op_value):
+                    raise ValidationError(
+                        '{0} must {1} {2} but it is {3} '
+                        'in env {4}'.format(
+                            name, op_function.__name__,
+                            op_value, value, env
                         )
+                    )
 
-                    # if not exists and not required cancel validation flow
-                    if not exists:
-                        return
-
-                    value = settings[name]
-
-                    # is there a callable condition?
-                    if self.condition is not None:
-                        if not self.condition(value):
-                            raise ValidationError(
-                                '{0} invalid for {1}({2}) '
-                                'in env {3}'.format(
-                                    name, self.condition.__name__,
-                                    value, env
-                                )
-                            )
-
-                    # operations
-                    for op_name, op_value in self.operations.items():
-                        op_function = getattr(validator_conditions, op_name)
-                        if not op_function(value, op_value):
-                            raise ValidationError(
-                                '{0} must {1} {2} but it is {3} '
-                                'in env {4}'.format(
-                                    name, op_function.__name__,
-                                    op_value, value, env
-                                )
-                            )
 
 
 class ValidatorList(list):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,6 +18,7 @@ codecov
 pytest
 pytest-cov
 pytest-xdist
+pytest-mock
 commentjson
 
 # style check

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -180,3 +180,25 @@ def test_validation_error(validator_instance, tmpdir):
     settings.validators.register(validator_instance)
     with pytest.raises(ValidationError):
         settings.validators.validate()
+
+
+def test_no_reload_on_single_env(tmpdir, mocker):
+    tmpfile = tmpdir.join('settings.toml')
+    tmpfile.write(TOML)
+
+    same_env_validator = Validator('VERSION', is_type_of=int, env='development')
+    other_env_validator = Validator('NAME', must_exist=True, env='production')
+
+    settings = LazySettings(
+        ENV_FOR_DYNACONF='DEVELOPMENt',
+        SETTINGS_MODULE_FOR_DYNACONF=str(tmpfile),
+    )
+    using_env = mocker.patch.object(settings, "using_env")
+
+    settings.validators.register(same_env_validator)
+    settings.validators.validate()
+    using_env.assert_not_called()
+
+    settings.validators.register(other_env_validator)
+    settings.validators.validate()
+    using_env.assert_called_once()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -186,8 +186,10 @@ def test_no_reload_on_single_env(tmpdir, mocker):
     tmpfile = tmpdir.join('settings.toml')
     tmpfile.write(TOML)
 
-    same_env_validator = Validator('VERSION', is_type_of=int, env='development')
-    other_env_validator = Validator('NAME', must_exist=True, env='production')
+    same_env_validator = Validator(
+        'VERSION', is_type_of=int, env='development')
+    other_env_validator = Validator(
+        'NAME', must_exist=True, env='production')
 
     settings = LazySettings(
         ENV_FOR_DYNACONF='DEVELOPMENt',

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -203,4 +203,5 @@ def test_no_reload_on_single_env(tmpdir, mocker):
 
     settings.validators.register(other_env_validator)
     settings.validators.validate()
-    using_env.assert_called_once()
+    using_env.assert_any_call('production')
+    assert using_env.call_count == 1


### PR DESCRIPTION
Hey @rochacbruno 👋 

### Problem statement

So I've been using Dynaconf extensively for the past few days, and something I noticed with adding more Validators to my settings was a significantly increased delay in validation. With debug logging enabled it became obvious that for every Validator instance added to the settings, all loaders were re-run when doing `settings.validators.validate()`, i.e. eloading the entire environment once per Validator. 

That makes sense when a Validator instance has the `env=` param set to anything not equal to `settings.current_env` but not when the Validator is defined with `env=None` or equal to `settings.current_env`. In that case the `using_env` contextmanager would superfluously reload the current environment.

### Proposal

In this PR I separated the internal validation logic in `Validator.validate()` into `Validator._validate_items()` and added a special case that would skip the `settings.using_env` contextmanager and go directly into the validation logic.

### Benefit

In a quick-and-dirty trial, I was able to improve the duration to go through 100 Validator instances from about 3 seconds down to less than .1 seconds. Afaics there's no down-side for changing the Validator's behavior this way.

```python
from datetime import datetime
from dynaconf import settings, Validator

vals = (Validator("SOMEVAR", ne="") for _ in range(100))

start = datetime.now()
settings.validators.register(*vals)
settings.validators.validate()

print(datetime.now()-start)
```

Cheers!