### PR TITLE
Fix #163 Allow disabling env prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ test_examples:
 	python example/specific_settings_modules/app.py
 	python example/django_example/manage.py test polls -v 2
 	PYTHONPATH=example/django_example DJANGO_SETTINGS_MODULE=foo.settings python example/django_example/standalone_script.py
+	python example/global_env_prefix/app.py
 
 	@echo '###############  Django Admin From root folder  ###############'
 	PYTHONPATH=./example/django_example/ DJANGO_SETTINGS_MODULE=foo.settings django-admin test polls -v 2

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -53,7 +53,7 @@ It can also be passed as parameters to extensions like `FlaskDynaconf` or set in
 | ENV_SWITCHER        | str     | Variable used to change working env              | ENV_FOR_DYNACONF                                 | ENV_SWITCHER_FOR_DYNACONF=MYPROGRAM_ENV                      |
 +---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
 | GLOBAL_ENV          | str     | | Prefix for exporting parameters as env vars    | "DYNACONF"                                       || GLOBAL_ENV_FOR_DYNACONF=MYPROGRAM                           |
-|                     |         | |                                                |                                                  || GLOBAL_ENV_FOR_DYNACONF=false                        |
+|                     |         | |                                                |                                                  || GLOBAL_ENV_FOR_DYNACONF=false                               |
 |                     |         | | Example:                                       |                                                  |                                                              |
 |                     |         | | If your program is called `MYPROGRAM`          |                                                  |                                                              |
 |                     |         | | you may want users to use `MYPROGRAM_FOO=bar`  |                                                  |                                                              |

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -52,8 +52,8 @@ It can also be passed as parameters to extensions like `FlaskDynaconf` or set in
 +---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
 | ENV_SWITCHER        | str     | Variable used to change working env              | ENV_FOR_DYNACONF                                 | ENV_SWITCHER_FOR_DYNACONF=MYPROGRAM_ENV                      |
 +---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
-| GLOBAL_ENV          | str     | | Prefix for exporting parameters as env vars    | "DYNACONF"                                       | GLOBAL_ENV_FOR_DYNACONF=MYPROGRAM                            |
-|                     |         | |                                                |                                                  |                                                              |
+| GLOBAL_ENV          | str     | | Prefix for exporting parameters as env vars    | "DYNACONF"                                       || GLOBAL_ENV_FOR_DYNACONF=MYPROGRAM                           |
+|                     |         | |                                                |                                                  || GLOBAL_ENV_FOR_DYNACONF="@none None"                        |
 |                     |         | | Example:                                       |                                                  |                                                              |
 |                     |         | | If your program is called `MYPROGRAM`          |                                                  |                                                              |
 |                     |         | | you may want users to use `MYPROGRAM_FOO=bar`  |                                                  |                                                              |

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -53,7 +53,7 @@ It can also be passed as parameters to extensions like `FlaskDynaconf` or set in
 | ENV_SWITCHER        | str     | Variable used to change working env              | ENV_FOR_DYNACONF                                 | ENV_SWITCHER_FOR_DYNACONF=MYPROGRAM_ENV                      |
 +---------------------+---------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------------------+
 | GLOBAL_ENV          | str     | | Prefix for exporting parameters as env vars    | "DYNACONF"                                       || GLOBAL_ENV_FOR_DYNACONF=MYPROGRAM                           |
-|                     |         | |                                                |                                                  || GLOBAL_ENV_FOR_DYNACONF="@none None"                        |
+|                     |         | |                                                |                                                  || GLOBAL_ENV_FOR_DYNACONF=false                        |
 |                     |         | | Example:                                       |                                                  |                                                              |
 |                     |         | | If your program is called `MYPROGRAM`          |                                                  |                                                              |
 |                     |         | | you may want users to use `MYPROGRAM_FOO=bar`  |                                                  |                                                              |

--- a/docs/guides/environment_variables.md
+++ b/docs/guides/environment_variables.md
@@ -97,6 +97,11 @@ The **DYNACONF_{param}** prefix is set by **GLOBAL_ENV_FOR_DYNACONF** and serves
 
 This prefix itself can be changed to something more significant for your application, however we recommend keeping **DYNACONF_{param}** as your global env prefix.
 
-Setting **GLOBAL_ENV_FOR_DYNACONF** to `'@none None'` will disable the prefix entirely and cause Dynaconf to load *all* environment variables.
+Setting **GLOBAL_ENV_FOR_DYNACONF** to `false` will disable the prefix entirely and cause Dynaconf to load *all* environment variables. When providing `GLOBAL_ENV_FOR_DYNACONF` as parameter to **LazySettings** or **settings.configure**, make sure to give it a Python-native `False`:
+
+```python
+from dynaconf import LazySettings
+settings = LazySettings(GLOBAL_ENV_FOR_DYNACONF=False)
+```
 
 > **NOTE**: See the [Configuring dynaconf](configuration.html) section in documentation to learn more on how to use `.env` variables to configure dynaconf behavior.

--- a/docs/guides/environment_variables.md
+++ b/docs/guides/environment_variables.md
@@ -95,6 +95,8 @@ Read more in [Getting Started Guide](usage.html)
 
 The **DYNACONF_{param}** prefix is set by **GLOBAL_ENV_FOR_DYNACONF** and serves only to be used in environment variables to override config values.
 
-This prefix itself can be changed to something more significant for your application, however we recommend kepping **DYNACONF_{param}** as your global env prefix.
+This prefix itself can be changed to something more significant for your application, however we recommend keeping **DYNACONF_{param}** as your global env prefix.
+
+Setting **GLOBAL_ENV_FOR_DYNACONF** to `'@none None'` will disable the prefix entirely and cause Dynaconf to load *all* environment variables.
 
 > **NOTE**: See the [Configuring dynaconf](configuration.html) section in documentation to learn more on how to use `.env` variables to configure dynaconf behavior.

--- a/dynaconf/loaders/env_loader.py
+++ b/dynaconf/loaders/env_loader.py
@@ -12,7 +12,7 @@ def load(obj, env=None, silent=True, key=None):
     `DYNACONF_` (default global) or `$(GLOBAL_ENV_FOR_DYNACONF)_`
     """
     global_env = obj.get('GLOBAL_ENV_FOR_DYNACONF')
-    if global_env is None or global_env.upper() != 'DYNACONF':
+    if global_env is False or global_env.upper() != 'DYNACONF':
         load_from_env(
             IDENTIFIER + '_global',
             key,
@@ -33,7 +33,7 @@ def load(obj, env=None, silent=True, key=None):
 
 def load_from_env(identifier, key, env, obj, silent):
     env_ = ""
-    if env is not None:
+    if env is not False:
         env = env.upper()
         env_ = '{0}_'.format(env)
     try:

--- a/dynaconf/loaders/env_loader.py
+++ b/dynaconf/loaders/env_loader.py
@@ -33,7 +33,7 @@ def load(obj, env=None, silent=True, key=None):
 
 def load_from_env(identifier, key, env, obj, silent):
     env_ = ""
-    if env:
+    if env is not None:
         env = env.upper()
         env_ = '{0}_'.format(env)
     try:

--- a/dynaconf/loaders/env_loader.py
+++ b/dynaconf/loaders/env_loader.py
@@ -12,7 +12,7 @@ def load(obj, env=None, silent=True, key=None):
     `DYNACONF_` (default global) or `$(GLOBAL_ENV_FOR_DYNACONF)_`
     """
     global_env = obj.get('GLOBAL_ENV_FOR_DYNACONF')
-    if global_env.upper() != 'DYNACONF':
+    if global_env is None or global_env.upper() != 'DYNACONF':
         load_from_env(
             IDENTIFIER + '_global',
             key,
@@ -32,12 +32,14 @@ def load(obj, env=None, silent=True, key=None):
 
 
 def load_from_env(identifier, key, env, obj, silent):
-    env = env.upper()  # noqa
-    env_ = '{0}_'.format(env)  # noqa
+    env_ = ""
+    if env:
+        env = env.upper()
+        env_ = '{0}_'.format(env)
     try:
         if key:
             value = os.environ.get(
-                '{0}_{1}'.format(env, key)
+                '{0}{1}'.format(env_, key)
             )
             if value:
                 obj.logger.debug(
@@ -49,8 +51,9 @@ def load_from_env(identifier, key, env, obj, silent):
                 )
                 obj.set(key, value, loader_identifier=identifier, tomlfy=True)
         else:
+            trim_len = len(env_)
             data = {
-                key.partition(env_)[-1]: parse_conf_data(data, tomlfy=True)
+                key[trim_len:]: parse_conf_data(data, tomlfy=True)
                 for key, data
                 in os.environ.items()
                 if key.startswith(env_)

--- a/example/global_env_prefix/.env
+++ b/example/global_env_prefix/.env
@@ -1,0 +1,9 @@
+# config vars
+EXAMPLE_VAR1=example_var1
+EXAMPLE_VAR2=example_var2
+
+_VAR1=_var1
+_VAR2=_var2
+
+VAR1=var1
+VAR2=var2

--- a/example/global_env_prefix/app.py
+++ b/example/global_env_prefix/app.py
@@ -11,6 +11,6 @@ print(settings.VAR1)
 print(settings.VAR2)
 
 print('no prefix at all')
-settings.configure(GLOBAL_ENV_FOR_DYNACONF=None)
+settings.configure(GLOBAL_ENV_FOR_DYNACONF=False)
 print(settings.VAR1)
 print(settings.VAR2)

--- a/example/global_env_prefix/app.py
+++ b/example/global_env_prefix/app.py
@@ -1,0 +1,16 @@
+from dynaconf import settings
+
+print('EXAMPLE_ prefix')
+settings.configure(GLOBAL_ENV_FOR_DYNACONF="EXAMPLE")
+print(settings.VAR1)
+print(settings.VAR2)
+
+print('_ prefix')
+settings.configure(GLOBAL_ENV_FOR_DYNACONF="")
+print(settings.VAR1)
+print(settings.VAR2)
+
+print('no prefix at all')
+settings.configure(GLOBAL_ENV_FOR_DYNACONF=None)
+print(settings.VAR1)
+print(settings.VAR2)

--- a/tests/test_env_loader.py
+++ b/tests/test_env_loader.py
@@ -119,7 +119,7 @@ def test_no_prefix():
     load_from_env(
         identifier="env_global",
         key=None,
-        env=None,
+        env=False,
         obj=settings,
         silent=True
     )

--- a/tests/test_env_loader.py
+++ b/tests/test_env_loader.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from dynaconf.loaders.env_loader import load
+from dynaconf.loaders.env_loader import load, load_from_env
 from dynaconf import settings  # noqa
 
 # GLOBAL ENV VARS
@@ -100,3 +100,39 @@ def test_cleaner():
     settings.clean()
     with pytest.raises(AttributeError):
         assert settings.HOSTNAME == 'host.com'
+
+
+def test_empty_string_prefix():
+    os.environ['_VALUE'] = 'underscored'
+    load_from_env(
+        identifier="env_global",
+        key=None,
+        env="",
+        obj=settings,
+        silent=True
+    )
+    assert settings.VALUE == 'underscored'
+
+
+def test_no_prefix():
+    os.environ['VALUE'] = 'no_prefix'
+    load_from_env(
+        identifier="env_global",
+        key=None,
+        env=None,
+        obj=settings,
+        silent=True
+    )
+    assert settings.VALUE == 'no_prefix'
+
+
+def test_none_as_string_prefix():
+    os.environ['NONE_VALUE'] = 'none as prefix'
+    load_from_env(
+        identifier="env_global",
+        key=None,
+        env="none",
+        obj=settings,
+        silent=True
+    )
+    assert settings.VALUE == 'none as prefix'


### PR DESCRIPTION
As discussed in #163, setting GLOBAL_ENV_FOR_DYNACONF='@none None', previously caused Dynaconf to only load env vars with a leading underscore, although it would be expected to load *all* vars. 

The necessary changes have been made to support explicit casting to NoneType through `'@none None'`, and forcing an "underscore-only prefix" by setting `GLOBAL_ENV_FOR_DYNACONF=""`. So:

* `GLOBAL_ENV_FOR_DYNACONF="EXAMPLE"` would load `EXAMPLE_VALUE=1` as settings.VALUE
* `GLOBAL_ENV_FOR_DYNACONF="none"` would load `NONE_VALUE=1` as settings.VALUE
* `GLOBAL_ENV_FOR_DYNACONF=""` would load `_VALUE=1` as settings.VALUE
* `GLOBAL_ENV_FOR_DYNACONF="@none None"` would load `VALUE=1`  as settings.VALUE, and all of the above verbatim, because no prefix would be enforced
