### PR TITLE
Add explicit call to main() on cli.py

### DIFF
--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -500,3 +500,7 @@ def validate(path):  # pragma: no cover
         click.echo(click.style(
             "Validation success!", fg="white", bg="green"
         ))
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()


### PR DESCRIPTION
To use click-web tool the module should be able to be explicitly called.

```
python -m dynaconf.cli
```