### PR TITLE
Fix `False` not being an acceptable env

### DIFF
--- a/dynaconf/loaders/base.py
+++ b/dynaconf/loaders/base.py
@@ -68,7 +68,7 @@ class BaseLoader(object):
 
         # compatibility with older versions that still uses [dynaconf] as
         # [default] env
-        global_env = self.obj.get("ENVVAR_PREFIX_FOR_DYNACONF")
+        global_env = self.obj.get("ENVVAR_PREFIX_FOR_DYNACONF") or "DYNACONF"
         if global_env not in env_list:
             env_list.append(global_env)
 

--- a/tests/test_envvar_prefix.py
+++ b/tests/test_envvar_prefix.py
@@ -1,10 +1,15 @@
 import os
 
+import pytest
+
 from dynaconf import LazySettings
 
 TOML = """
 [global]
 var = "my value"
+
+[false]
+thisvar = "should not be set"
 """
 
 
@@ -14,8 +19,24 @@ def test_envvar_prefix_lazysettings(tmpdir):
     tmpfile.write(TOML)
 
     settings = LazySettings(
-        ENVVAR_PREFIX_FOR_DYNACONF=False, SETTINGS_FILE_FOR_DYNACONF=str(tmpfile)
+        ENVVAR_PREFIX_FOR_DYNACONF=False,
+        SETTINGS_FILE_FOR_DYNACONF=str(tmpfile),
     )
 
     assert settings.VAR == "my value"
     assert settings.DYNACONF_PREFIXED_VAR == "this is prefixed"
+
+
+def test_envvar_prefix_false_from_envvar(tmpdir):
+    os.environ["DYNACONF_PREFIXED_VAR"] = "this is prefixed"
+    os.environ["ENVVAR_PREFIX_FOR_DYNACONF"] = "false"
+    tmpfile = tmpdir.mkdir("sub").join("test_no_envvar_prefix.toml")
+    tmpfile.write(TOML)
+
+    settings = LazySettings(SETTINGS_FILE_FOR_DYNACONF=str(tmpfile))
+
+    assert settings.VAR == "my value"
+    assert settings.DYNACONF_PREFIXED_VAR == "this is prefixed"
+
+    with pytest.raises(AttributeError):
+        assert settings.THISVAR == "should not be set"

--- a/tests/test_envvar_prefix.py
+++ b/tests/test_envvar_prefix.py
@@ -40,3 +40,4 @@ def test_envvar_prefix_false_from_envvar(tmpdir):
 
     with pytest.raises(AttributeError):
         assert settings.THISVAR == "should not be set"
+    del os.environ["ENVVAR_PREFIX_FOR_DYNACONF"]

--- a/tests/test_envvar_prefix.py
+++ b/tests/test_envvar_prefix.py
@@ -1,0 +1,21 @@
+import os
+
+from dynaconf import LazySettings
+
+TOML = """
+[global]
+var = "my value"
+"""
+
+
+def test_envvar_prefix_lazysettings(tmpdir):
+    os.environ["DYNACONF_PREFIXED_VAR"] = "this is prefixed"
+    tmpfile = tmpdir.mkdir("sub").join("test_no_envvar_prefix.toml")
+    tmpfile.write(TOML)
+
+    settings = LazySettings(
+        ENVVAR_PREFIX_FOR_DYNACONF=False, SETTINGS_FILE_FOR_DYNACONF=str(tmpfile)
+    )
+
+    assert settings.VAR == "my value"
+    assert settings.DYNACONF_PREFIXED_VAR == "this is prefixed"


### PR DESCRIPTION
When using `ENVVAR_PREFIX_FOR_DYNACONF=False` in LazySettings in combination with for example a TOML settings file, the base loader will raise an unexpected exception trying to `.lower`case the boolean. This MR appends `DYNACONF` as compatibility global_env instead when the `ENVVAR_PREFIX_FOR_DYNACONF` is `False`.

**Steps to reproduce the issue:**

1. Create TOML settings file `settings.toml` with the following contents:
  ```toml
  [global]
  var = 1
  ```
2. Try instantiating with `ENVVAR_PREFIX_FOR_DYNACONF=False`, and accessing an arbitrary value from the settings like so:

```python
settings = LazySettings(
    ENVVAR_PREFIX_FOR_DYNACONF=False, 
    SETTINGS_FILE_FOR_DYNACONF="settings.toml"
)
assert settings.VAR == 1
```

I added testcases to ensure this undefined behavior is properly prevented in the future. 

Cheers! 👋 