### PR TITLE
removed pytest-xdist

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-py.test --boxed -v --cov-config .coveragerc --cov=dynaconf -l tests/ --junitxml=junit/test-results.xml
+py.test -v --cov-config .coveragerc --cov=dynaconf -l tests/ --junitxml=junit/test-results.xml

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ test_redis:
 	@cd example/redis_example;pwd;python redis_example.py | grep -c redis_works
 
 test_only:
-	py.test --boxed -v --cov-config .coveragerc --cov=dynaconf -l --tb=short --maxfail=1 tests/
+	py.test -v --cov-config .coveragerc --cov=dynaconf -l --tb=short --maxfail=1 tests/
 	coverage xml
 
 coverage-report:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,7 +17,6 @@ gitchangelog
 codecov
 pytest
 pytest-cov
-pytest-xdist
 pytest-mock
 commentjson
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,5 @@ whitelist_externals=
     cd
     python
 commands =
-    py.test --boxed -v --cov=dynaconf -l --tb=short --maxfail=1 {posargs}
+    py.test -v --cov=dynaconf -l --tb=short --maxfail=1 {posargs}
     ; make test_examples
-


### PR DESCRIPTION
Now tests run in a separate tmpdir so xdist is not needed anymore