### PR TITLE
Hide DeprecationWarning from Pytest when testing for them

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -3,8 +3,8 @@ import os
 from dynaconf import LazySettings
 
 
-def test_dynaconf_namespace_renamed(tmpdir):
-    settings = LazySettings(
+def test_dynaconf_namespace_renamed(tmpdir, recwarn):
+    params = dict(
         DYNACONF_NAMESPACE="FOO",
         DYNACONF_SETTINGS_MODULE="foo.py",
         SETTINGS_MODULE="foo.py",
@@ -12,6 +12,11 @@ def test_dynaconf_namespace_renamed(tmpdir):
         DYNACONF_SILENT_ERRORS=True,
         DYNACONF_ALWAYS_FRESH_VARS=["BAR"],
     )
+    settings = LazySettings(**params)
+
+    for param, warning in zip(params.keys(), recwarn):
+        assert issubclass(warning.category, DeprecationWarning)
+        assert param in str(warning.message)
 
     assert settings.ENV_FOR_DYNACONF == "FOO"
     assert settings.SETTINGS_FILE_FOR_DYNACONF == "foo.py"
@@ -20,8 +25,8 @@ def test_dynaconf_namespace_renamed(tmpdir):
     assert settings.FRESH_VARS_FOR_DYNACONF == ["BAR"]
 
 
-def test_namespace_for_dynaconf_renamed(tmpdir):
-    settings = LazySettings(
+def test_namespace_for_dynaconf_renamed(tmpdir, recwarn):
+    params = dict(
         NAMESPACE_FOR_DYNACONF="FOO",
         DYNACONF_SETTINGS_MODULE="foo.py",
         SETTINGS_MODULE="foo.py",
@@ -29,6 +34,11 @@ def test_namespace_for_dynaconf_renamed(tmpdir):
         DYNACONF_SILENT_ERRORS=True,
         DYNACONF_ALWAYS_FRESH_VARS=["BAR"],
     )
+    settings = LazySettings(**params)
+
+    for param, warning in zip(params.keys(), recwarn):
+        assert issubclass(warning.category, DeprecationWarning)
+        assert param in str(warning.message)
 
     assert settings.ENV_FOR_DYNACONF == "FOO"
     assert settings.SETTINGS_FILE_FOR_DYNACONF == "foo.py"
@@ -37,7 +47,7 @@ def test_namespace_for_dynaconf_renamed(tmpdir):
     assert settings.FRESH_VARS_FOR_DYNACONF == ["BAR"]
 
 
-def test_envvar_prefix_for_dynaconf(tmpdir):
+def test_envvar_prefix_for_dynaconf(tmpdir, recwarn):
     os.environ["AWESOMEAPP_FOO"] = "1"
     os.environ["AWESOMEAPP_BAR"] = "false"
     os.environ["AWESOMEAPP_LIST"] = '["item1", "item2"]'
@@ -51,6 +61,10 @@ def test_envvar_prefix_for_dynaconf(tmpdir):
     assert settings.FLOAT == 42.2
 
     settings2 = LazySettings(GLOBAL_ENV_FOR_DYNACONF="AWESOMEAPP")
+
+    assert len(recwarn) == 1
+    assert issubclass(recwarn[0].category, DeprecationWarning)
+    assert "GLOBAL_ENV_FOR_DYNACONF" in str(recwarn[0].message)
 
     assert settings2.FOO == 1
     assert settings2.BAR is False

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,50 +1,32 @@
 import os
 
+import pytest
+
 from dynaconf import LazySettings
 
 
-def test_dynaconf_namespace_renamed(tmpdir, recwarn):
-    params = dict(
-        DYNACONF_NAMESPACE="FOO",
-        DYNACONF_SETTINGS_MODULE="foo.py",
-        SETTINGS_MODULE="foo.py",
-        PROJECT_ROOT=str(tmpdir),
-        DYNACONF_SILENT_ERRORS=True,
-        DYNACONF_ALWAYS_FRESH_VARS=["BAR"],
-    )
-    settings = LazySettings(**params)
+@pytest.mark.parametrize(
+    "deprecated,value,new",
+    [
+        ("DYNACONF_NAMESPACE", "FOO", "ENV_FOR_DYNACONF"),
+        ("NAMESPACE_FOR_DYNACONF", "FOO", "ENV_FOR_DYNACONF"),
+        ("DYNACONF_SETTINGS_MODULE", "foo.py", "SETTINGS_FILE_FOR_DYNACONF"),
+        ("SETTINGS_MODULE", "foo.py", "SETTINGS_FILE_FOR_DYNACONF"),
+        ("PROJECT_ROOT", "./", "ROOT_PATH_FOR_DYNACONF"),
+        ("DYNACONF_SILENT_ERRORS", True, "SILENT_ERRORS_FOR_DYNACONF"),
+        ("DYNACONF_ALWAYS_FRESH_VARS", ["BAR"], "FRESH_VARS_FOR_DYNACONF"),
+        ("GLOBAL_ENV_FOR_DYNACONF", "MYAPP", "ENVVAR_PREFIX_FOR_DYNACONF"),
+        ("BASE_NAMESPACE_FOR_DYNACONF", "THIS", "DEFAULT_ENV_FOR_DYNACONF"),
+    ],
+)
+def test_dynaconf_namespace_renamed(tmpdir, recwarn, deprecated, value, new):
+    settings = LazySettings(**{deprecated: value})
 
-    for param, warning in zip(params.keys(), recwarn):
-        assert issubclass(warning.category, DeprecationWarning)
-        assert param in str(warning.message)
-
-    assert settings.ENV_FOR_DYNACONF == "FOO"
-    assert settings.SETTINGS_FILE_FOR_DYNACONF == "foo.py"
-    assert settings.ROOT_PATH_FOR_DYNACONF == str(tmpdir)
-    assert settings.SILENT_ERRORS_FOR_DYNACONF is True
-    assert settings.FRESH_VARS_FOR_DYNACONF == ["BAR"]
-
-
-def test_namespace_for_dynaconf_renamed(tmpdir, recwarn):
-    params = dict(
-        NAMESPACE_FOR_DYNACONF="FOO",
-        DYNACONF_SETTINGS_MODULE="foo.py",
-        SETTINGS_MODULE="foo.py",
-        PROJECT_ROOT_FOR_DYNACONF=str(tmpdir),
-        DYNACONF_SILENT_ERRORS=True,
-        DYNACONF_ALWAYS_FRESH_VARS=["BAR"],
-    )
-    settings = LazySettings(**params)
-
-    for param, warning in zip(params.keys(), recwarn):
-        assert issubclass(warning.category, DeprecationWarning)
-        assert param in str(warning.message)
-
-    assert settings.ENV_FOR_DYNACONF == "FOO"
-    assert settings.SETTINGS_FILE_FOR_DYNACONF == "foo.py"
-    assert settings.ROOT_PATH_FOR_DYNACONF == str(tmpdir)
-    assert settings.SILENT_ERRORS_FOR_DYNACONF is True
-    assert settings.FRESH_VARS_FOR_DYNACONF == ["BAR"]
+    assert len(recwarn) == 1
+    assert issubclass(recwarn[0].category, DeprecationWarning)
+    assert deprecated in str(recwarn[0].message)
+    assert new in str(recwarn[0].message)
+    assert settings.get(new) == value
 
 
 def test_envvar_prefix_for_dynaconf(tmpdir, recwarn):


### PR DESCRIPTION
Previously whenever running the testsuite, Pytest would output the `DeprecationWarning`s that it was testing for in `test_compat.py`. I added the recwarn fixture to test if dynaconf outputs the right warnings, and at the same time hide the overly verbose output for the tests.