### PR TITLE
Replace logging.basicConfig with handler on logger

### DIFF
--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -65,15 +65,19 @@ class DynaconfDict(dict):
 def _logger(level):
     import logging
 
-    logging.basicConfig(
-        format=(
+    formatter = logging.Formatter(
+        fmt=(
             "%(asctime)s,%(msecs)d %(levelname)-8s "
             "[%(filename)s:%(lineno)d - %(funcName)s] %(message)s"
         ),
         datefmt="%Y-%m-%d:%H:%M:%S",
-        level=getattr(logging, level, "DEBUG"),
     )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
     logger = logging.getLogger("dynaconf")
+    logger.addHandler(handler)
+    logger.setLevel(level=getattr(logging, level, "DEBUG"))
     return logger
 
 


### PR DESCRIPTION
In Python libraries it is advisable to _not_ use `logging.basicConfig` since the root logger configuration should be left to the application _using_ the library. To have a dynaconf-wide specific logger instance, a logger can be instantiated with a dedicated handler and it's own logging level.

This way a calling application can easily override these settings (directly or through `fileConfig`, `dictConfig`, etc.) while the previous behavior and response to `DEBUG_LEVEL_FOR_DYNACONF` of dynaconf stays intact.