### PR TITLE
Catch BoxKeyError when contents are TOML-parsable but not keyable

### DIFF
--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -2,9 +2,9 @@ import json
 import os
 
 import toml
+from box import BoxKeyError
 
 from dynaconf.utils.boxing import DynaBox
-
 
 true_values = ("t", "true", "enabled", "1", "on", "yes", "True")
 false_values = ("f", "false", "disabled", "0", "off", "no", "False", "")
@@ -29,7 +29,7 @@ def parse_with_toml(data):
     """Uses TOML syntax to parse data"""
     try:
         return toml.loads("key={}".format(data), DynaBox).key
-    except toml.TomlDecodeError:
+    except (toml.TomlDecodeError, BoxKeyError):
         return data
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 import io
 import os
 
+import pytest
+
 from dynaconf import default_settings
 from dynaconf.utils import ensure_a_list
 from dynaconf.utils import Missing
@@ -92,6 +94,11 @@ def test_tomlfy():
         "key": "value",
         "v": 1,
     }
+
+
+@pytest.mark.parametrize("test_input", ["something=42"])
+def test_tomlfy_unparseable(test_input):
+    assert parse_conf_data(test_input, tomlfy=True) == test_input
 
 
 def test_missing_sentinel():


### PR DESCRIPTION
I discovered what I would consider a bug, but @rochacbruno, you may correct me here, maybe this is expected behavior:

When an env var contains contents that are technically TOML-parsable but can not be retrieved from the (Dyna)Box, that raises a BoxKeyError, and causes the entire env_loader to drop out and parse none of the env vars at all.

To reproduce:

```bash
export DYNACONF_SOME_VAR="something=42"
python -c 'from dynaconf import settings; print(settings.SOME_VAR)'
```
Throws:

```
2019-05-07:15:13:29,634 ERROR    [env_loader.py:55 - load_from_env] "'DynaBox' object has no attribute 'KEY'"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/jan/Library/Caches/pypoetry/virtualenvs/protagonist-py3.7/lib/python3.7/site-packages/dynaconf/base.py", line 107, in __getattr__
    return getattr(self._wrapped, name)
AttributeError: 'Settings' object has no attribute 'SOME_VAR'
```

This PR catches the occurring BoxKeyError in `dynaconf.utils.parse_conf.parse_with_toml()`, which passes the unmodified value of the env var (`something=42` in the example above) into the settings (which I'd consider expected behavior).