### PR TITLE
Fix #207 allow python module path name for includes

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -7,6 +7,7 @@ from contextlib import suppress
 from dynaconf import default_settings
 from dynaconf.loaders import default_loader
 from dynaconf.loaders import enable_external_loaders
+from dynaconf.loaders import py_loader
 from dynaconf.loaders import settings_loader
 from dynaconf.loaders import yaml_loader
 from dynaconf.utils import BANNER
@@ -777,6 +778,14 @@ class Settings(object):
             already_loaded = set()
             for _filename in files:
                 self.logger.debug("Processing file %s", _filename)
+
+                if py_loader.try_to_load_from_py_module_name(
+                    obj=self, name=_filename, silent=True
+                ):
+                    # if it was possible to load from module name
+                    # continue the loop.
+                    continue
+
                 filepath = os.path.join(self._root_path, _filename)
                 self.logger.debug("File path is %s", filepath)
                 # Handle possible *.globs sorted alphanumeric

--- a/tests/test_nested_loading.py
+++ b/tests/test_nested_loading.py
@@ -319,3 +319,58 @@ def test_programmatically_file_load(tmpdir):
     # to persist it needs to go to `INCLUDES_FOR_DYNACONF` variable
     with pytest.raises(AttributeError):
         assert settings.PLUGIN_VALUE == "plugin"
+
+
+def test_include_via_python_module_name(tmpdir):
+    """Check if an include can be a Python module name"""
+    settings_file = tmpdir.join("settings.toml")
+    settings_file.write(
+        """
+       [default]
+       default_var = 'default'
+    """
+    )
+
+    dummy_folder = tmpdir.mkdir("dummy")
+    dummy_folder.join("dummy_module.py").write('FOO = "164110"')
+    dummy_folder.join("__init__.py").write('print("initing dummy...")')
+
+    settings = LazySettings(
+        SETTINGS_FILE_FOR_DYNACONF=str(settings_file),
+        INCLUDES_FOR_DYNACONF=["dummy.dummy_module"],
+    )
+
+    assert settings.DEFAULT_VAR == "default"
+    assert settings.FOO == "164110"
+
+
+def test_include_via_python_module_name_and_otjers(tmpdir):
+    """Check if an include can be a Python module name plus others"""
+    settings_file = tmpdir.join("settings.toml")
+    settings_file.write(
+        """
+       [default]
+       default_var = 'default'
+    """
+    )
+
+    dummy_folder = tmpdir.mkdir("dummy")
+    dummy_folder.join("dummy_module.py").write('FOO = "164110"')
+    dummy_folder.join("__init__.py").write('print("initing dummy...")')
+
+    yaml_file = tmpdir.join("otherfile.yaml")
+    yaml_file.write(
+        """
+       default:
+         yaml_value: 748632
+    """
+    )
+
+    settings = LazySettings(
+        SETTINGS_FILE_FOR_DYNACONF=str(settings_file),
+        INCLUDES_FOR_DYNACONF=["dummy.dummy_module", "otherfile.yaml"],
+    )
+
+    assert settings.DEFAULT_VAR == "default"
+    assert settings.FOO == "164110"
+    assert settings.YAML_VALUE == 748632

--- a/tests/test_py_loader.py
+++ b/tests/test_py_loader.py
@@ -1,8 +1,11 @@
 import io
 import os
 
+import pytest
+
 from dynaconf import default_settings
 from dynaconf.loaders.py_loader import load
+from dynaconf.loaders.py_loader import try_to_load_from_py_module_name
 from dynaconf.utils import DynaconfDict
 
 
@@ -33,3 +36,28 @@ def test_py_loader_from_module(tmpdir):
     load(settings, "dummy.dummy_module")
 
     assert settings.exists("FOO")
+
+
+def test_try_to_load_from_py_module_name(tmpdir):
+    settings = DynaconfDict()
+    dummy_folder = tmpdir.mkdir("dummy")
+
+    dummy_folder.join("dummy_module.py").write('FOO = "bar"')
+    dummy_folder.join("__init__.py").write('print("initing dummy...")')
+
+    try_to_load_from_py_module_name(settings, "dummy.dummy_module")
+
+    assert settings.exists("FOO")
+
+
+def test_negative_try_to_load_from_py_module_name(tmpdir):
+    settings = DynaconfDict()
+    with pytest.raises(ImportError):
+        try_to_load_from_py_module_name(settings, "foo.bar.dummy")
+
+
+def test_silently_try_to_load_from_py_module_name(tmpdir):
+    settings = DynaconfDict()
+    try_to_load_from_py_module_name(settings, "foo.bar.dummy", silent=True)
+
+    assert settings.exists("FOO") is False


### PR DESCRIPTION
Dynaconf right now can load includes, the includes should be a list of paths like `['/path/to/file.yaml', '/path/to/glob/*.toml']`

**Problem**

It should also allow includes by `['python.module.paths'..]` instead of only `glob-able` paths.

**Describe the solution you'd like**
I want to be able to use:

```py
INCLUDES_FOR_DYNACONF=['python_module.submodule.settings', ...]
```

**Additional context**

This is request by  https://pulp.plan.io/issues/5290

The changes should go on lines:

https://github.com/rochacbruno/dynaconf/blob/master/dynaconf/base.py#L757-L799

And dynaconf already has ability to load Python modules on: https://github.com/rochacbruno/dynaconf/blob/master/dynaconf/loaders/py_loader.py
