### PR TITLE
Fix #197 add support for DOTTED__ENV__VARS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test_examples:
 	cd example/;pwd;python full_example.py | grep -c full_example || exit 1
 	cd example/;pwd;python compat.py
 	cd example/app;pwd;python app.py | grep -c app || exit 1
+	cd example/dunder;pwd;python app.py || exit 1
 	cd example/app_with_dotenv;pwd;python app.py | grep -c app_with_dotenv || exit 1
 	cd example/merge_configs;pwd;python app.py | grep -c merge_configs || exit 1
 	cd example/dynaconf_merge;pwd;python app.py

--- a/docs/guides/usage.md
+++ b/docs/guides/usage.md
@@ -391,7 +391,26 @@ In an environment variable:
 export DYNACONF_DATABASE='{password=1234, dynaconf_merge=true}'
 ```
 
-Or in an additional file (e.g `settings.yaml, .secrets.yaml, etc`):
+It is also possible to use nested  `dunder` traversal like:
+
+```bash
+export DYNACONF_DATABASE__password=1234
+export DYNACONF_DATABASE__user=admin
+export DYNACONF_DATABASE__ARGS__timeout=30
+export DYNACONF_DATABASE__ARGS__retries=5
+```
+
+Each `__` is parsed as a level traversing thought dict keys. read more in [environment variables](environment_variables.html#nested-keys-in-dictionaries-via-environment-variables)
+
+So the above will result in
+
+```py
+DATABASE = {'password': 1234, 'user': 'admin', 'ARGS': {'timeout': 30, 'retries': 5}}
+```
+
+> **IMPORTANT** lower case keys are respected only on *nix systems, unfortunately Windows environment variables are case insensitive and Python reads it as all upper cases, that means that if you are running on Windows the dictionary can have only upper case keys.
+
+Or in an additional file (e.g `settings.yaml, .secrets.yaml, etc`) by using `dynaconf_merge` token:
 
 ```yaml
 default:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -88,11 +88,14 @@ Dynaconf - Easy and Powerful Settings Configuration for Python
 Who is using Dynaconf?
 ^^^^^^^^^^^^^^^^^^^^^^
 
-- Pulp Project - Django - (Red Hat)
-- Ansible Galaxy - Django - (Red Hat)
-- Insights QE (Red Hat)
+- Pulp Project - Django - (RedHat)
+- Ansible Galaxy - Django - (RedHat)
+- Insights QE (RedHat)
+- CloudForms QE (RedHat)
 - Seek AI & Catho Job boards - Flask - (on AI APIs)
 - Quokka CMS - Flask
+- iNNOVO Cloud GmbH
+- Teraki
 
 Are you using Dynaconf? Please `give feedback`_
 

--- a/dynaconf/default_settings.py
+++ b/dynaconf/default_settings.py
@@ -119,6 +119,13 @@ ENCODING_FOR_DYNACONF = get("ENCODING_FOR_DYNACONF", "utf-8")
 # Merge objects on load
 MERGE_ENABLED_FOR_DYNACONF = get("MERGE_ENABLED_FOR_DYNACONF", False)
 
+# BY default `__` is the separator for nested env vars
+# export `DYNACONF__DATABASE__server=server.com`
+# export `DYNACONF__DATABASE__PORT=6666`
+# Should result in settings.DATABASE == {'server': 'server.com', 'PORT': 6666}
+# To disable it one can set `NESTED_SEPARATOR_FOR_DYNACONF=false`
+NESTED_SEPARATOR_FOR_DYNACONF = get("NESTED_SEPARATOR_FOR_DYNACONF", "__")
+
 # The env var specifying settings module
 ENVVAR_FOR_DYNACONF = get("ENVVAR_FOR_DYNACONF", "SETTINGS_FILE_FOR_DYNACONF")
 

--- a/dynaconf/loaders/env_loader.py
+++ b/dynaconf/loaders/env_loader.py
@@ -1,4 +1,4 @@
-import os
+from os import environ
 
 from dotenv import cli as dotenv_cli
 
@@ -27,7 +27,7 @@ def load_from_env(identifier, key, env, obj, silent):
         env_ = "{0}_".format(env)
     try:
         if key:
-            value = os.environ.get("{0}{1}".format(env_, key))
+            value = environ.get("{0}{1}".format(env_, key))
             if value:
                 obj.logger.debug(
                     "env_loader: loading by key: %s:%s (%s:%s)",
@@ -41,7 +41,7 @@ def load_from_env(identifier, key, env, obj, silent):
             trim_len = len(env_)
             data = {
                 key[trim_len:]: parse_conf_data(data, tomlfy=True)
-                for key, data in os.environ.items()
+                for key, data in environ.items()
                 if key.startswith(env_)
             }
             if data:
@@ -60,4 +60,4 @@ def load_from_env(identifier, key, env, obj, silent):
 def write(settings_path, settings_data, **kwargs):
     """Write data to .env file"""
     for key, value in settings_data.items():
-        dotenv_cli.set_key(str(settings_path), key.upper(), str(value))
+        dotenv_cli.set_key(str(settings_path), key, str(value))

--- a/dynaconf/loaders/py_loader.py
+++ b/dynaconf/loaders/py_loader.py
@@ -32,7 +32,8 @@ def load_from_python_object(
     obj, mod, settings_module, key=None, identifier=None
 ):
     for setting in dir(mod):
-        if setting.isupper():
+        # at least 3 first chars should be upper to be considered a setting var
+        if setting[:3].isupper():
             if key is None or key == setting:
                 setting_value = getattr(mod, setting)
                 obj.logger.debug(

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -23,9 +23,11 @@ def object_merge(old, new, unique=False):
 
     :param unique: When set to True existing list items are not set.
     """
+    if old == new:
+        # Nothing to merge
+        return
+
     if isinstance(old, list) and isinstance(new, list):
-        if old == new:
-            return
         for item in old[::-1]:
             if unique and item in new:
                 continue
@@ -36,6 +38,15 @@ def object_merge(old, new, unique=False):
                 new[key] = value
             else:
                 object_merge(value, new[key])
+
+        # Cleanup of MetaValues on New dict
+        for key, value in new.items():
+            if getattr(new[key], "dynaconf_reset", False):
+                # new Reset triggers cleanup of existing data
+                new[key] = new[key].value
+            elif getattr(new[key], "dynaconf_del", False):
+                # new Del triggers deletion of existing data
+                new.pop(key, None)
 
 
 class DynaconfDict(dict):

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -9,6 +9,33 @@ from dynaconf.utils.boxing import DynaBox
 true_values = ("t", "true", "enabled", "1", "on", "yes", "True")
 false_values = ("f", "false", "disabled", "0", "off", "no", "False", "")
 
+
+class MetaValue:
+    """A Marker to trigger specific actions on `set` and `object_merge`"""
+
+    meta_value = True
+
+    def __init__(self, value):
+        self.value = parse_conf_data(value, tomlfy=True)
+
+    def __repr__(self):
+        return "{_class}({value}) on {_id}".format(
+            _class=self.__class__.__name__, value=self.value, _id=id(self)
+        )
+
+
+class Reset(MetaValue):
+    """Triggers an existing key to be reset to its value"""
+
+    dynaconf_reset = True
+
+
+class Del(MetaValue):
+    """Triggers an existing key to be deleted"""
+
+    dynaconf_del = True
+
+
 converters = {
     "@int": int,
     "@float": float,
@@ -16,13 +43,15 @@ converters = {
         lambda value: True if str(value).lower() in true_values else False
     ),
     "@json": json.loads,
+    # Meta Values to trigger pre assignment actions
+    "@reset": lambda value: Reset(value),
+    "@del": lambda value: Del(value),
     # Special markers to be used as placeholders e.g: in prefilled forms
     # will always return None when evaluated
     "@note": lambda value: None,
     "@comment": lambda value: None,
     "@null": lambda value: None,
     "@none": lambda value: None,
-    "@reset": lambda value: value,
 }
 
 

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -22,6 +22,7 @@ converters = {
     "@comment": lambda value: None,
     "@null": lambda value: None,
     "@none": lambda value: None,
+    "@reset": lambda value: value,
 }
 
 

--- a/example/dunder/.env
+++ b/example/dunder/.env
@@ -1,0 +1,5 @@
+INCLUDES_FOR_DYNACONF="['other_settings.py']"
+DYNACONF_FILES__all="['env']"
+DYNACONF_FILES__last="@reset ['env']"
+DYNACONF_FILES__loaded__TYPES="{env=true}"
+DYNACONF_FILES__nothere="@del "

--- a/example/dunder/app.py
+++ b/example/dunder/app.py
@@ -1,0 +1,17 @@
+from dynaconf import settings
+
+settings.FILES
+
+keys = ["default", "env", "py"]
+
+print(settings.FILES)
+for key in keys:
+    assert settings.FILES.loaded.TYPES[key] is True
+    assert settings.FILES.loaded["TYPES"][key] is True
+
+    assert key in settings.FILES.all
+    assert key in settings.FILES["all"]
+
+assert settings.FILES.last == ["env"]
+assert "nothere" not in settings.FILES
+print(settings.FILES)

--- a/example/dunder/other_settings.py
+++ b/example/dunder/other_settings.py
@@ -1,0 +1,3 @@
+FILES__all = ["py"]
+FILES__last = "@reset ['py']"
+FILES__loaded__TYPES = {"py": True}

--- a/example/dunder/settings.py
+++ b/example/dunder/settings.py
@@ -1,0 +1,6 @@
+FILES = {
+    "all": ["default"],
+    "last": ["default"],
+    "loaded": {"TYPES": {"default": True}},
+    "nothere": "hello",
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import sys
 
@@ -55,3 +56,13 @@ def go_to_tmpdir(request):
     # Chdir only for the duration of the test.
     with tmpdir.as_cwd():
         yield
+
+
+@pytest.fixture(scope="module")
+def clean_env(request):
+    backup = copy.deepcopy(os.environ)
+    for key in os.environ.keys():
+        if key.startswith("DYNACONF_"):
+            del os.environ[key]
+    yield
+    os.environ.update(backup)

--- a/tests/test_ini_loader.py
+++ b/tests/test_ini_loader.py
@@ -163,3 +163,16 @@ def test_using_env(tmpdir):
     with settings.using_env("DEVELOPMENT", filename=str(tmpfile)):
         assert settings.HOST == "devserver.com"
     assert settings.HOST == "prodserver.com"
+
+
+def test_load_dunder():
+    """Test load with dunder settings"""
+    ini = """
+    a = "a,b"
+    [foo]
+    colors__white__code = '#FFFFFF'
+    COLORS__white__name = 'white'
+    """
+    load(settings, filename=ini, env="FOO")
+    assert settings.COLORS.white.code == "#FFFFFF"
+    assert settings.COLORS.white.name == "white"

--- a/tests/test_json_loader.py
+++ b/tests/test_json_loader.py
@@ -163,3 +163,18 @@ def test_using_env(tmpdir):
     with settings.using_env("DEVELOPMENT", filename=str(tmpfile)):
         assert settings.HOST == "devserver.com"
     assert settings.HOST == "prodserver.com"
+
+
+def test_load_dunder():
+    """Test loading with dunder settings"""
+    _JSON = """
+    {
+      "foo": {
+        "colors__yellow__code": "#FFCC00",
+        "COLORS__yellow__name": "Yellow"
+      }
+    }
+    """
+    load(settings, filename=_JSON, env="FOO")
+    assert settings.COLORS.yellow.code == "#FFCC00"
+    assert settings.COLORS.yellow.name == "Yellow"

--- a/tests/test_nested_loading.py
+++ b/tests/test_nested_loading.py
@@ -344,7 +344,7 @@ def test_include_via_python_module_name(tmpdir):
     assert settings.FOO == "164110"
 
 
-def test_include_via_python_module_name_and_otjers(tmpdir):
+def test_include_via_python_module_name_and_others(tmpdir):
     """Check if an include can be a Python module name plus others"""
     settings_file = tmpdir.join("settings.toml")
     settings_file.write(

--- a/tests/test_py_loader.py
+++ b/tests/test_py_loader.py
@@ -4,12 +4,13 @@ import os
 import pytest
 
 from dynaconf import default_settings
+from dynaconf import LazySettings
 from dynaconf.loaders.py_loader import load
 from dynaconf.loaders.py_loader import try_to_load_from_py_module_name
 from dynaconf.utils import DynaconfDict
 
 
-def test_py_loader_form_file(tmpdir):
+def test_py_loader_from_file(tmpdir):
 
     settings = DynaconfDict()
     dummy_path = tmpdir.join("dummy_module.py")
@@ -61,3 +62,36 @@ def test_silently_try_to_load_from_py_module_name(tmpdir):
     try_to_load_from_py_module_name(settings, "foo.bar.dummy", silent=True)
 
     assert settings.exists("FOO") is False
+
+
+def test_py_loader_from_file_dunder(clean_env, tmpdir):
+    """Test load with dunder settings"""
+
+    settings = LazySettings(
+        DATABASES={
+            "default": {
+                "NAME": "db",
+                "ENGINE": "module.foo.engine",
+                "ARGS": {"timeout": 30},
+                "PORTS": [123, 456],
+            }
+        }
+    )
+    dummy_path = tmpdir.join("dummy_module.py")
+    with io.open(
+        str(dummy_path), "w", encoding=default_settings.ENCODING_FOR_DYNACONF
+    ) as f:
+        f.write('F = "bar"')
+        f.write("\n")
+        f.write('COLORS__white__code = "#FFFFFF"')
+        f.write("\n")
+        f.write('DATABASES__default__ENGINE = "other.module"')
+
+    load(settings, "dummy_module.py")
+    os.remove("dummy_module.py")
+    load(settings, "dummy_module.py")  # will be ignored not found
+
+    assert settings.get("F") == "bar"
+    assert settings.COLORS == {"white": {"code": "#FFFFFF"}}
+    assert settings.DATABASES.default.NAME == "db"
+    assert settings.DATABASES.default.ENGINE == "other.module"

--- a/tests/test_toml_loader.py
+++ b/tests/test_toml_loader.py
@@ -166,3 +166,16 @@ def test_using_env(tmpdir):
     with settings.using_env("DEVELOPMENT", filename=str(tmpfile)):
         assert settings.HOST == "devserver.com"
     assert settings.HOST == "prodserver.com"
+
+
+def test_load_dunder():
+    """Test load with dunder settings"""
+    toml = """
+    a = "a,b"
+    [foo]
+    colors__gray__code = '#CCCCCC'
+    COLORS__gray__name = 'Gray'
+    """
+    load(settings, filename=toml, env="FOO")
+    assert settings.COLORS.gray.code == "#CCCCCC"
+    assert settings.COLORS.gray.name == "Gray"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,6 +121,18 @@ def test_missing_sentinel():
     assert str(missing) == "<dynaconf.missing>"
 
 
+def test_meta_values():
+    reset = parse_conf_data("@reset [1, 2]", tomlfy=True)
+    assert reset.value == [1, 2]
+    assert reset.dynaconf_reset is True
+    assert "Reset([1, 2])" in repr(reset)
+
+    _del = parse_conf_data("@del", tomlfy=True)
+    assert _del.value == ""
+    assert _del.dynaconf_del is True
+    assert "Del()" in repr(_del)
+
+
 def test_merge_existing_list():
     existing = ["bruno", "karla"]
     object_merge(existing, existing)

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -188,3 +188,17 @@ def test_using_env(tmpdir):
     with settings.using_env("DEVELOPMENT", filename=str(tmpfile)):
         assert settings.HOST == "devserver.com"
     assert settings.HOST == "prodserver.com"
+
+
+def test_load_dunder():
+    """Test load with dunder settings"""
+    yaml = """
+    foo:
+       bar: blaz
+       zaz: naz
+       colors__black__code: '#000000'
+       COLORS__black__name: Black
+    """
+    load(settings, filename=yaml, env="FOO")
+    assert settings.COLORS.black.code == "#000000"
+    assert settings.COLORS.black.name == "Black"

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,5 @@ whitelist_externals=
     cd
     python
 commands =
-    py.test -v --cov=dynaconf -l --tb=short --maxfail=1 {posargs}
+    py.test -sv --cov=dynaconf -l --tb=short --maxfail=1 {posargs}
     ; make test_examples


### PR DESCRIPTION
Fix #197 

## Merging new data to existing variables

### Nested keys in dictionaries via environment variables.

> **New in 2.0.5**
> 
> This is useful for `Django` settings.

Lets say you have a configuration like this:

`settings.py`

```py
DATABASES = {
    'default': {
        'NAME': 'db',
        'ENGINE': 'module.foo.engine',
        'ARGS': {'timeout': 30}
    }
}
```

And  now you want to change the values of `ENGINE` to `other.module`, via environment variables you can use the format `${ENVVAR_PREFIX}_${VARIABLE}__${NESTED_ITEM}__${NESTED_ITEM}`

Each `__` (dunder, a.k.a *double underline*) denotes access to nested elements in a dictionary.

So 

```py
DATABASES['default']['ENGINE'] = 'other.module'
```

Can be expressed as environment variables as:

```bash
export DYNACONF_DATABASES__default__ENGINE=other.module
```

This will result in

```py
DATABASES = {
    'default': {
        'NAME': 'db',
        'ENGINE': 'other.module',
        'ARGS': {'timeout': 30}
    }
}
```

> **IMPORTANT** lower case keys are respected only on *nix systems, unfortunately Windows environment variables are case insensitive and Python reads it as all upper cases, that means that if you are running on Windows the dictionary can have only upper case keys.

Now if you want to add a new item to `ARGS` key:

```bash
export DYNACONF_DATABASES__default__ARGS__retries=10
```

This will result in

```py
DATABASES = {
    'default': {
        'NAME': 'db',
        'ENGINE': 'other.module',
        'ARGS': {'timeout': 30, 'retries': 10}
    }
}
```

and you can also pass a `toml` like dictionary to be merged with existing `ARGS` key.

```bash
export DYNACONF_DATABASES__default__ARGS='{timeout=50, size=1}'
```

will result in

```py
DATABASES = {
    'default': {
        'NAME': 'db',
        'ENGINE': 'other.module',
        'ARGS': {'retries': 10, 'timeout': 50, 'size': 1}
    }
}
```

Now if you want to clean an existing nested attribute you can use the `@reset` token on exported env var.

```bash
export DYNACONF_DATABASES__default__ARGS='@reset {}'
```

This will result in

```py
DATABASES = {
    'default': {
        'NAME': 'db',
        'ENGINE': 'other.module',
        'ARGS': {}
    }
}
```

And also you can do a `@reset` followed by a re-assignment

> Dynaconf env vars are parsed using `toml` so the format for dictionaries is a bit different.

```bash
export DYNACONF_DATABASES__default__ARGS='@reset {timeout=90}'
```

This will result in

```py
DATABASES = {
    'default': {
        'NAME': 'db',
        'ENGINE': 'other.module',
        'ARGS': {'timeout': 90}
    }
}
```

And if in any case you need to completely remove that key from the dictionary:

```bash
export DYNACONF_DATABASES__default__ARGS='@del'
```

This will result in

```py
DATABASES = {
    'default': {
        'NAME': 'db',
        'ENGINE': 'other.module'
    }
}
```