### PR TITLE
Adds `from_env` method and change `_store` to be a `DynaBox`

### DIFF
--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -1,6 +1,5 @@
 import importlib
 import io
-import json
 import os
 import pprint
 import sys

--- a/dynaconf/contrib/django_dynaconf_v2.py
+++ b/dynaconf/contrib/django_dynaconf_v2.py
@@ -57,7 +57,9 @@ def load(django_settings_module_name=None, **kwargs):  # pragma: no cover
         k: v for k, v in django_settings_module.__dict__.items() if k.isupper()
     }
     options.update(kwargs)
-    options.setdefault("SKIP_FILES_FOR_DYNACONF", [settings_file])
+    options.setdefault(
+        "SKIP_FILES_FOR_DYNACONF", [settings_file, "dynaconf_merge"]
+    )
     options.setdefault("ROOT_PATH_FOR_DYNACONF", _root_path)
     options.setdefault("ENVVAR_PREFIX_FOR_DYNACONF", "DJANGO")
     options.setdefault("ENV_SWITCHER_FOR_DYNACONF", "DJANGO_ENV")

--- a/dynaconf/loaders/__init__.py
+++ b/dynaconf/loaders/__init__.py
@@ -82,6 +82,7 @@ def settings_loader(
     found_files = []
     modules_names = []
     for item in files:
+        item = str(item)  # Ensure str in case of LocalPath/Path is passed.
         if item.endswith(ct.ALL_EXTENSIONS + (".py",)):
             p_root = obj._root_path or (
                 os.path.dirname(found_files[0]) if found_files else None

--- a/dynaconf/loaders/ini_loader.py
+++ b/dynaconf/loaders/ini_loader.py
@@ -8,7 +8,7 @@ from dynaconf.utils import object_merge
 
 try:
     from configobj import ConfigObj
-except ImportError as e:  # pragma: no cover
+except ImportError:  # pragma: no cover
     ConfigObj = None
 
 

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -169,7 +169,7 @@ def warn_deprecations(data):
     if data.get("MERGE_ENABLED_FOR_DYNACONF"):
         warnings.warn(
             "MERGE_ENABLED_FOR_DYNACONF is deprecated "
-            "instead it is prefered to use the local merge feature "
+            "instead it is preferred to use the local merge feature "
             "see: https://dynaconf.readthedocs.io/en/latest/guides/usage.html"
             "#merging-existing-values",
             DeprecationWarning,

--- a/example/django_example_compat/foo/settings.py
+++ b/example/django_example_compat/foo/settings.py
@@ -31,7 +31,9 @@ settings = dynaconf.DjangoDynaconf(
 
 
 # test
-assert settings.ENVVAR_PREFIX_FOR_DYNACONF == "MYWEBAPP"
+assert (
+    settings.ENVVAR_PREFIX_FOR_DYNACONF == "MYWEBAPP"
+), settings.ENVVAR_PREFIX_FOR_DYNACONF
 assert settings.GLOBAL_ENV_FOR_DYNACONF == "MYWEBAPP"
 assert settings.PLUGIN_ENABLED is True
 assert settings.PLUGIN_LIST == ["plugin1", "plugin2"]


### PR DESCRIPTION
Ref #218 
`settings._store` is now a `DynaBox` and that allows first level keys to be lower case.

Ref #211 
`settings` now has a `from_env` method to allow switching branches without side effects.

## Switching working environments

You can switch between existing environments using:

- `from_env`: (**recommended**) Will create a new settings instance pointing to defined env.
- `setenv`: Will set the existing instance to defined env.
- `using_env`: Context manager that will have defined env only inside its scope.

### from_env

> **New in 2.0.5**

Return a new isolated settings object pointing to specified env.

Example of settings.toml::

```ini
[development]
message = 'This is in dev'
foo = 1
[other]
message = 'this is in other env'
bar = 2
```

Program::

```py
>>> from dynaconf import settings
>>> print(settings.MESSAGE)
'This is in dev'
>>> print(settings.FOO)
1
>>> print(settings.BAR)
AttributeError: settings object has no attribute 'BAR'
```

Then you can use `from_env`:

```py
>>> print(settings.from_env('other').MESSAGE)
'This is in other env'
>>> print(settings.from_env('other').BAR)
2
>>> print(settings.from_env('other').FOO)
AttributeError: settings object has no attribute 'FOO'
```

The existing `settings` object remains the same.

```py
>>> print(settings.MESSAGE)
'This is in dev'
```

You can assign new settings objects to different `envs` like:

```py
development_settings = settings.from_env('development')
other_settings = settings.from_env('other')
```

And you can choose if the variables from different `envs` will be chained and overridden in a sequence:

```py
all_settings = settings.from_env('development', keep=True).from_env('other', keep=True)

>>> print(all_settings.MESSAGE)
'This is in other env'
>>> print(all_settings.FOO)
1
>>> print(all_settings.BAR)
2
```

The variables from [development] are loaded keeping pre-loaded values, then the variables from [other] are loaded keeping pre-loaded from [development] and overriding it.

### setenv

Will change `in_place` the `env` for the existing object.

```python
from dynaconf import settings

settings.setenv('other')
# now values comes from [other] section of config
assert settings.MESSAGE == 'This is in other env'

settings.setenv()
# now working env are back to previous
```

### using_env

Using context manager

```python
from dynaconf import settings

with settings.using_env('other'):
    # now values comes from [other] section of config
    assert settings.MESSAGE == 'This is in other env'

# existing settings back to normal after the context manager scope
assert settings.MESSAGE == 'This is in dev'
```