### PR TITLE
Fixing self._root_path to fall back to os.getcwd()

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -892,7 +892,9 @@ class Settings(object):
                     # continue the loop.
                     continue
 
-                filepath = os.path.join(self._root_path, _filename)
+                filepath = os.path.join(
+                    self._root_path or os.getcwd(), _filename
+                )
                 self.logger.debug("File path is %s", filepath)
                 # Handle possible *.globs sorted alphanumeric
                 for path in sorted(glob.glob(filepath)):


### PR DESCRIPTION
I was hitting an error like below:
```---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-c4a32dfb6df1> in <module>
----> 1 cfme_data.management_systems

/var/ci/workspace/kkulkarn-9315/integration_tests/cfme/utils/config_data.py in __getattr__(self, key)
     14 
     15     def __getattr__(self, key):
---> 16         self.config = self.settings[key.upper()]
     17         return self.config
     18 

/var/ci/cfme_venv3/lib64/python3.7/site-packages/dynaconf/utils/functional.py in inner(self, *args)
      8     def inner(self, *args):
      9         if self._wrapped is empty:
---> 10             self._setup()
     11         return func(self._wrapped, *args)
     12 

/var/ci/cfme_venv3/lib64/python3.7/site-packages/dynaconf/base.py in _setup(self)
    124         settings_module = os.environ.get(environment_variable)
    125         self._wrapped = Settings(
--> 126             settings_module=settings_module, **self._kwargs
    127         )
    128         self.logger.debug("Lazy Settings _setup ...")

/var/ci/cfme_venv3/lib64/python3.7/site-packages/dynaconf/base.py in __init__(self, settings_module, **kwargs)
    188         self._defaults = kwargs
    189         self.logger.debug("Initializing Dynaconf (%s)", self._store)
--> 190         self.execute_loaders()
    191 
    192     def __call__(self, *args, **kwargs):

/var/ci/cfme_venv3/lib64/python3.7/site-packages/dynaconf/base.py in execute_loaders(self, env, silent, key, filename)
    855             self.logger.debug("Dynaconf executing: %s", loader.__name__)
    856             loader.load(self, env, silent=silent, key=key)
--> 857         self.load_includes(env, silent=silent, key=key)
    858         self.logger.debug("Loaded Files: %s", deduplicate(self._loaded_files))
    859 

/var/ci/cfme_venv3/lib64/python3.7/site-packages/dynaconf/base.py in load_includes(self, env, silent, key)
    866             from IPython import embed
    867             embed()
--> 868             self.load_file(path=includes, env=env, silent=silent, key=key)
    869             # ensure env vars are the last thing loaded after all includes
    870             last_loader = self.loaders and self.loaders[-1]

/var/ci/cfme_venv3/lib64/python3.7/site-packages/dynaconf/base.py in load_file(self, path, env, silent, key)
    894                     # continue the loop.
    895                     continue
--> 896                 filepath = os.path.join(self._root_path, _filename)
    897                 self.logger.debug("File path is %s", filepath)
    898                 # Handle possible *.globs sorted alphanumeric

/usr/lib64/python3.7/posixpath.py in join(a, *p)
     78     will be discarded.  An empty last part will result in a path that
     79     ends with a separator."""
---> 80     a = os.fspath(a)
     81     sep = _get_sep(a)
     82     path = a

TypeError: expected str, bytes or os.PathLike object, not NoneType

```

To fix this I had to use `os.getcwd()` . I think one could use `ROOT_PATH_FOR_DYNACONF` but I feel `os.getcwd()` is sensible default.

Please review. 

Thanks. 