### PR TITLE
fix crash on empty settings

### DIFF
--- a/dynaconf/loaders/base.py
+++ b/dynaconf/loaders/base.py
@@ -122,7 +122,7 @@ class BaseLoader(object):
                 env = env.lower()  # lower for better comparison
                 data = {}
                 try:
-                    data = source_data[env]
+                    data = source_data[env] or {}
                 except KeyError:
                     if env not in base_envs:
                         message = "%s_loader: %s env not defined in %s" % (

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -280,3 +280,12 @@ def test_explicit_local_files(tmpdir):
     assert conf.MUSIC.current.volume == 100
     assert conf.MUSIC.current.title == "Led Zeppelin - Immigrant Song"
     assert conf.get("music.current.even.inner.element") is True
+
+def test_empty_env(tmpdir):
+    """Assert empty env is not crashing on load."""
+    settings_file_yaml = """
+    default: ~
+    """
+    tmpdir.join("settings.yaml").write(settings_file_yaml)
+    settings = LazySettings()
+    settings.reload()

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -281,6 +281,7 @@ def test_explicit_local_files(tmpdir):
     assert conf.MUSIC.current.title == "Led Zeppelin - Immigrant Song"
     assert conf.get("music.current.even.inner.element") is True
 
+
 def test_empty_env(tmpdir):
     """Assert empty env is not crashing on load."""
     settings_file_yaml = """


### PR DESCRIPTION
Dynaconf crashes when used with empty settings.

### Steps to reproduce:

Create a settings.yaml file with the following content:
`default: ~`

Run the following:
```
from dynaconf import settings
settings.reload()
```

It crashes with an `AttributeError: 'NoneType' object has no attribute 'items'`

### Fix

I managed to trace it to a bug in the BaseLoader:
```
data = {}
try:
    data = source_data[env]
except KeyError:
[...]
data = {upperfy(k): v for k, v in data.items()}
```

This works fine when env doesn't exist, or when environment contains values, but "source_data[env]" is `None` when passed an empty settings file. Adding `data = source_data[env] or {}` fixes it and is consistent with the definition of data that was the line before.