### PR TITLE
Fix #251 recursive call was using mutable memoized data

### DIFF
--- a/example/issues/251_dotted_unexistent/app.py
+++ b/example/issues/251_dotted_unexistent/app.py
@@ -1,0 +1,26 @@
+from dynaconf import settings
+
+print("As dict:")
+print(settings.as_dict())
+
+assert settings.FOO == {"bar": "hello"}
+assert settings.FOO.bar == "hello"
+
+assert settings.get("FOO") == {"bar": "hello"}
+assert settings.get("foo") == {"bar": "hello"}
+assert settings.get("foo.bar") == "hello", settings.get("foo.bar")
+
+assert settings.get("foo.zaz") is None
+assert settings.get("non.zaz") is None
+assert settings.get("non.zaz", 3) == 3
+print("With list as default 1:")
+assert settings.get("non.existing.key", [1, 2, 3]) == [1, 2, 3]
+assert settings.get("non.zaz", 3) == 3
+
+assert settings.get("foo.bar") == "hello"
+
+print("With 0 as default:")
+assert settings.get("non.existing.key", 0) == 0
+
+print("With list as default 2:")
+assert settings.get("non.existing.key", [4, 5, 6]) == [4, 5, 6]

--- a/example/issues/251_dotted_unexistent/settings.py
+++ b/example/issues/251_dotted_unexistent/settings.py
@@ -1,0 +1,1 @@
+FOO = {"bar": "hello"}


### PR DESCRIPTION
Fix #251 
replaced with recursive passing of parent data.

NOTE to SELF: Never! use a mutable memoized data
              Always use `==` to compare when you dont know the types