### PR TITLE
Add support for detecting duplicate validators being added

### DIFF
--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -83,6 +83,26 @@ class Validator(object):
         else:
             self.envs = None
 
+    def __eq__(self, other):
+        if self is other:
+            return True
+
+        identical_attrs = (
+            getattr(self, attr) == getattr(other, attr)
+            for attr in (
+                "names",
+                "must_exist",
+                "when",
+                "condition",
+                "operations",
+                "envs",
+            )
+        )
+        if all(identical_attrs):
+            return True
+
+        return False
+
     def validate(self, settings):
         """Raise ValidationError if invalid"""
 
@@ -160,7 +180,9 @@ class ValidatorList(list):
         self.settings = settings
 
     def register(self, *args):
-        self.extend(args)
+        for validator in args:
+            if validator not in self:
+                self.append(validator)
 
     def validate(self):
         for validator in self:


### PR DESCRIPTION
Yet another unsolicited PR by yours truly. 😁 

Recently we stumbled upon an issue in using Dynaconf when adding validators. Essentially we are using a plugin-based approach in an application, that creates many objects of the same class that adds its own `Validator` objects to the global settings instance. By nature of the class, these Validator objects are all equal in _contents_ but are not the same _object_.

Over the runtime of the application this would lead to adding the same Validators to the settings over and over again, bloating the ValidatorList object, and of course every subsequent run of `settings.validators.validate()` would take longer than the previous. 

This PR adds the `__eq__` method to the Validator class, allowing recursively checking the equality of two Validator instances. That method is furthermore being used in the ValidatorList class to check if a validator that's being registered already has an equal counterpart in the list and, if so, ignores it.

For quality check I went for the most obvious approach, by simply iterating over instance attributes (as created by `__init__`), and checking equality on them.

Let me know what you think!