### PR TITLE
Update sensitive_secrets.md

### DIFF
--- a/docs/guides/sensitive_secrets.md
+++ b/docs/guides/sensitive_secrets.md
@@ -94,7 +94,7 @@ Dynaconf can handle this via `SECRETS_FOR_DYNACONF` environment variable.
 ex:
 
 ```bash
-export SECRETS_FOR_DYNACONF=/path/to/settings.toml{json|py|ini|yaml}
+export SECRETS_FOR_DYNACONF=/path/to/secrets.toml{json|py|ini|yaml}
 ```
 
 If that variable exists in your environment then Dynaconf will also load it.


### PR DESCRIPTION
Updated the file reference from `settings`.toml{json|py|ini|yaml} to the convention used thus far; `secrets`.toml{json|py|ini|yaml}. This can help alleviate the slightest chance of the information becoming misleading or confusing. This can also be ignored if Dynaconf can be set to search for secrets in files other than `secrets.<ext>`