### PR TITLE
Pin python-box version because of a breaking release

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,15 +3,17 @@ redis
 wheel
 twine
 PyYAML
-toml
 flask>=1.0
-python-box
-python-dotenv
 setuptools>=38.6.0
 configobj
 hvac
 django
 gitchangelog
+
+python-box<4.0.0
+python-dotenv<=0.10.3
+toml<=0.10.0
+click<=7.0
 
 # testing
 codecov

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,12 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms="any",
-    install_requires=["python-box", "python-dotenv", "toml", "click"],
+    install_requires=[
+        "python-box<4.0.0",
+        "python-dotenv<=0.10.3",
+        "toml<=0.10.0",
+        "click<=7.0",
+    ],
     tests_require=[
         "pytest",
         "pytest-cov",


### PR DESCRIPTION
The release of python-box https://github.com/cdgriffith/Box/pull/116
is a breaking change.

So pinning this until this project addapts.

Also pinning other direct deps.

Reported on: https://twitter.com/maszanchi/status/1210123455594545154