### PR TITLE
Fix pre-commit to run python3 rather than python3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
         args: [--line-length=79]
-        language_version: python3.7
+        language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
     hooks:


### PR DESCRIPTION
Running "make all" in a python3.6 environment breaks on pre-commit, because of a call to "python3.7". Fixed by calling "python3".