### PR TITLE
adoverriding strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ test_examples:
 	cd example/app_with_dotenv;pwd;python app.py
 	cd example/merge_enabled;pwd;python app.py
 	cd example/new_merge;pwd;python app.py
+	cd example/overriding;pwd;python app.py
 	cd example/dynaconf_merge;pwd;python app.py
 	cd example/multiple_sources;pwd;python app.py
 	cd example/multiple_folders;pwd;python app.py

--- a/example/overriding/.env
+++ b/example/overriding/.env
@@ -1,0 +1,1 @@
+INCLUDES_FOR_DYNACONF = ["user_settings.py"]

--- a/example/overriding/app.py
+++ b/example/overriding/app.py
@@ -1,0 +1,9 @@
+from dynaconf import settings
+
+
+assert settings.REST_FRAMEWORK.DEFAULT_AUTHENTICATION_CLASSES == [
+    "rest_framework.authentication.SessionAuthentication",
+    # user_settings.py will remove the line below
+    # 'pulpcore.app.authentication.PulpRemoteUserAuthentication',
+    "rest_framework.authentication.BasicAuthentication",
+], settings.REST_FRAMEWORK.DEFAULT_AUTHENTICATION_CLASSES

--- a/example/overriding/settings.py
+++ b/example/overriding/settings.py
@@ -1,0 +1,23 @@
+REST_FRAMEWORK = {
+    "URL_FIELD_NAME": "pulp_href",
+    "DEFAULT_FILTER_BACKENDS": (
+        "django_filters.rest_framework.DjangoFilterBackend",
+    ),
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPaginat",
+    "PAGE_SIZE": 100,
+    "DEFAULT_PERMISSION_CLASSES": (
+        "rest_framework.permissions.IsAuthenticated",
+    ),
+    # THE GOAL IS TO OVERRIDE THIS `DEFAULT_AUTHENTICATION_CLASSES` KEY
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        # Keep this value
+        "rest_framework.authentication.SessionAuthentication",
+        # Remove this value
+        "pulpcore.app.authentication.PulpRemoteUserAuthentication",
+        # keep this value
+        "rest_framework.authentication.BasicAuthentication",
+    ),
+    # Override is done in `user_settings.py`
+    "UPLOADED_FILES_USE_URL": False,
+    "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
+}

--- a/example/overriding/user_settings.py
+++ b/example/overriding/user_settings.py
@@ -1,0 +1,28 @@
+# Alternative 1
+# This works
+# https://dynaconf.readthedocs.io/en/latest/guides/environment_variables.html#merging-new-data-to-existing-variables
+
+REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES = "@reset ['rest_framework.authentication.SessionAuthentication','rest_framework.authentication.BasicAuthentication']"  # noqa
+
+
+# Alternative 2 (NOT IMPLEMENTED YET)
+# TODO: Implement this merging override strategy
+
+_REST_FRAMEWORK = {
+    # Mark the `REST_FRAMEWORK` as a candidate for merging
+    # specify the merge strategy for specific keys
+    # strategies must be:
+    # reset: clean existing value before reassign
+    # merge: (the default) merge with existing values
+    # unique: merge only if value doesn't already exists in the collection
+    # conditional(expr): expression to evaluate as a conditional
+    "dynaconf_merge": {
+        "DEFAULT_AUTHENTICATION_CLASSES": {"strategy": "reset"}
+        # ^ the key will be cleaned before assign new values
+    },
+    # Set keys you want to assign
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.BasicAuthentication",
+    ),
+}


### PR DESCRIPTION
[13:04:45] <@bmbouter> rochacbruno: can you help me w/ a dynaconf example I'm writing for the docs
[13:04:59] <rochacbruno> bmbouter: sure!
[13:05:04] <rochacbruno> I hope so
[13:05:12] <bmbouter> I want an example of overridding the DEFAULT_AUTHENTICATION_CLASSES key in this dict https://github.com/pulp/pulpcore/blob/master/pulpcore/app/settings.py#L125
[13:05:16] <bmbouter> and leave the other keys alone
[13:05:36] <bmbouter> and my goal is to keep L#126 and L#128 but effectively remove L#127
[13:07:05] <rochacbruno> bmbouter: let me see, one moment
[13:08:44] <bmbouter> thank you!


## Current working Solution

Lets say you have:

```py
# settings.py
DATA = {
  'FOO': [1, 2, 3]
}
```

and your goal is to override `settings.DATA.FOO` to be equal to `[1, 3]` (remove the item `2`

On `user_settings.py`

```py
DATA__FOO = "@reset [1, 3]"
```

Explain:

- The use of `__` (double under) will traverse the keys
- The token `@reset` will mark that value to be cleaned before reassign
- The `[1,3]` is a `toml` list.

## New idea

 There is another approach proposed in this source code, not implemented yet. https://github.com/rochacbruno/dynaconf/pull/289/files#diff-fa16fca7bdc631655faad52678fa1dfaR11
