### PR TITLE
Fix #145 allow string formatting using envvars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ test_examples:
 	cd example/;pwd;python compat.py
 	cd example/app;pwd;python app.py
 	cd example/dunder;pwd;python app.py
+	cd example/format;pwd;python app.py
 	cd example/app_with_dotenv;pwd;python app.py
 	cd example/merge_enabled;pwd;python app.py
 	cd example/new_merge;pwd;python app.py

--- a/docs/guides/environment_variables.md
+++ b/docs/guides/environment_variables.md
@@ -54,6 +54,14 @@ DYNACONF_NONE='@none None'
 
 # toml syntax does not allow mixed type arrays so use @json
 DYNACONF_ARRAY='@json [42, 3.14, "hello", true, ["otherarray"], {"foo": "bar"}]'
+
+# Lazily formatted string can access env vars and settings variables.
+
+# using str.format
+DYNACONF_DATABASE_PATH="@format {env[HOME]}/.config/databases/{this.DB_NAME}"
+
+# using jinja2
+DYNACONF_DATABASE_PATH="@jinja {{env.HOME}}/.config/databases/{{this.DB_NAME}}"
 ```
 
 > **NOTE**: Older versions of Dynaconf used the `@casting` prefixes for env vars like `export DYNACONF_INTEGER='@int 123'` still works but this casting is deprecated in favor of using TOML syntax described above. To disable the `@casting` do `export AUTO_CAST_FOR_DYNACONF=false`

--- a/docs/guides/usage.md
+++ b/docs/guides/usage.md
@@ -501,7 +501,85 @@ settings.load_file(path="/path/to/file.toml")  # list or `;/,` separated allowed
 
 > **NOTE**: programmatically loaded file is not persisted, once `env` is changed via `setenv|ugin_env`, or a `reload` or `configure` is invoked it will be cleaned, to persist it needs to go to `INCLUDES_FOR_DYNACONF` variable or you need to load it programmatically again.
 
-## Merging existing values
+## Template substitutions
+
+Dynaconf has 2 tokens to enable string substitutions `@format` and `@jinja`.
+
+### @format token
+
+Dynaconf allows template substitutions for strings values, by using the `@format` token prefix and including placeholders accepted by Python's `str.format` method Dynaconf will call
+it lazily upon access time.
+
+The call will be like:
+
+```py
+"<YOURVALUE>".format(env=os.environ, this=dynaconf.settings)
+```
+
+So in your string you can refer to environment variables via `env` object, and also to variables defined int the settings object itself via `this` reference. It is lazily evaluated on access it will use the final value for a settings regardless the order of load.
+
+Example:
+
+```bash
+export PROGRAM_NAME=calculator
+```
+
+settings.toml
+
+```toml
+[default]
+DB_NAME = "mydb.db"
+
+[development]
+DB_PATH = "@format {env[HOME]}/{this.current_env}/{env[PROGRAM_NAME]}/{this.DB_NAME}"
+```
+
+- `{env[HOME]}` is the same as `os.environ["HOME"]` or `$HOME` in the shell.
+- `{this.current_env}` is the same as `settings.current_env`
+- `{env[PROGRAM_NAME]}` is the same as `os.environ["PROGRAM_NAME"]` or `$PROGRAM_NAME` in the shell.
+- `{this.DB_NAME}` is the same as `settins.DB_NAME` or `settings["DB_NAME"]`
+
+so in your `program`
+
+```py
+from dynaconf import settings
+
+settings.DB_PATH == '~/DEVELOPMENT/calculator/mydb.db'
+```
+
+### @jinja token
+
+If `jinja2` package is installed then dynaconf will also allow the use jinja to render string values.
+
+Example:
+
+```bash
+export PROGRAM_NAME=calculator
+```
+
+settings.toml
+
+```toml
+[default]
+DB_NAME = "mydb.db"
+
+[development]
+DB_PATH = "@jinja {{env.HOME}}/{{this.current_env | lower}}/{{env['PROGRAM_NAME']}}/{{this.DB_NAME}}"
+```
+
+so in your `program`
+
+```py
+from dynaconf import settings
+
+settings.DB_PATH == '~/development/calculator/mydb.db'
+```
+
+The main difference is that Jinja allows some Python expressions to be avaluated such as `{% for, if, while %}` and also supports calling methods and has lots of filters like `| lower`.
+
+Jinja supports its built-in filters listed in [Builtin Filters Page](http://jinja.palletsprojects.com/en/master/templates/#builtin-filters) and Dynaconf includes aditional filters for `os.path` module: `abspath`. `realpath`, `relpath`, `basename` and `dirname` and usage is like: `VALUE = "@jinja {{this.FOO | abspath}}"`
+
+## Merging existing data structures
 
 If your settings has existing variables of types `list` ot `dict` and you want to `merge` instead of `override` then 
 the `dynaconf_merge` and `dynaconf_merge_unique` stanzas can mark that variable as a candidate for merging.

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -25,6 +25,7 @@ from dynaconf.utils.files import find_file
 from dynaconf.utils.functional import empty
 from dynaconf.utils.functional import LazyObject
 from dynaconf.utils.parse_conf import converters
+from dynaconf.utils.parse_conf import evaluate_lazy_format
 from dynaconf.utils.parse_conf import parse_conf_data
 from dynaconf.utils.parse_conf import true_values
 from dynaconf.validator import ValidatorList
@@ -90,6 +91,7 @@ class LazySettings(LazyObject):
         self._kwargs = kwargs
         super(LazySettings, self).__init__()
 
+    @evaluate_lazy_format
     def __getattr__(self, name):
         """Allow getting keys from self.store using dot notation"""
         if self._wrapped is empty:
@@ -276,6 +278,7 @@ class Settings(object):
             ".".join(keys), default=default, parent=result, **kwargs
         )
 
+    @evaluate_lazy_format
     def get(
         self,
         key,

--- a/example/format/.env
+++ b/example/format/.env
@@ -1,0 +1,1 @@
+USERNAME='robert_plant'

--- a/example/format/app.py
+++ b/example/format/app.py
@@ -1,0 +1,18 @@
+import os
+
+from dynaconf import settings
+
+assert settings.get("USERNAME") is None
+assert settings.DATABASE_NAME == "my_database.db"
+assert os.environ["USERNAME"] == "robert_plant"
+
+DB_PATH = "/home/robert_plant/databases/my_database.db"
+assert settings.DATABASE_PATH == DB_PATH, settings.DATABASE_PATH
+print(settings.DATABASE_PATH)
+
+
+DB_PATH_JINJA = "/home/robert_plant/development/my_database.db"
+assert (
+    settings.DATABASE_PATH_JINJA == DB_PATH_JINJA
+), settings.DATABASE_PATH_JINJA
+print(settings.DATABASE_PATH_JINJA)

--- a/example/format/settings.toml
+++ b/example/format/settings.toml
@@ -1,0 +1,6 @@
+[default]
+database_name = 'my_database.db'
+
+[development]
+database_path = '@format /home/{env[USERNAME]}/databases/{this[database_name]}'
+database_path_jinja = '@jinja /home/{{env.USERNAME}}/{{this.current_env | lower}}/{{this["database_name"] }}'


### PR DESCRIPTION
## Template substitutions 

Dynaconf has 2 tokens to enable string substitutions `@format` and `@jinja`.

### @format token

Dynaconf allows template substitutions for strings values, by using the `@format` token prefix and including placeholders accepted by Python's `str.format` method Dynaconf will call
it lazily upon access time.

The call will be like:

```py
"<YOURVALUE>".format(env=os.environ, this=dynaconf.settings)
```

So in your string you can refer to environment variables via `env` object, and also to variables defined int the settings object itself via `this` reference. It is lazily evaluated on access it will use the final value for a settings regardless the order of load.

Example:

```bash
export PROGRAM_NAME=calculator
```

settings.toml

```toml
[default]
DB_NAME = "mydb.db"

[development]
DB_PATH = "@format {env[HOME]}/{this.current_env}/{env[PROGRAM_NAME]}/{this.DB_NAME}"
```

- `{env[HOME]}` is the same as `os.environ["HOME"]` or `$HOME` in the shell.
- `{this.current_env}` is the same as `settings.current_env`
- `{env[PROGRAM_NAME]}` is the same as `os.environ["PROGRAM_NAME"]` or `$PROGRAM_NAME` in the shell.
- `{this.DB_NAME}` is the same as `settins.DB_NAME` or `settings["DB_NAME"]`

so in your `program`

```py
from dynaconf import settings

settings.DB_PATH == '~/development/calculator/mydb.db'
```

### @jinja token

If `jinja2` package is installed then dynaconf will also allow the use jinja to render string values.

Example:

```bash
export PROGRAM_NAME=calculator
```

settings.toml

```toml
[default]
DB_NAME = "mydb.db"

[development]
DB_PATH = "@jinja {{env.HOME}}/{{this.current_env | lower}}/{{env['PROGRAM_NAME']}}/{{this.DB_NAME}}"
```

so in your `program`

```py
from dynaconf import settings

settings.DB_PATH == '~/development/calculator/mydb.db'
```

The main difference is that Jinja allows some Python expressions to be avaluated such as `{% for, if, while %}` and also supports calling methods and has lots of filters like `| lower`.