### PR TITLE
Considering `silent` on import_from_filename

### DIFF
--- a/dynaconf/loaders/py_loader.py
+++ b/dynaconf/loaders/py_loader.py
@@ -112,8 +112,6 @@ def import_from_filename(obj, filename, silent=False):  # pragma: no cover
     if not filename.endswith(".py"):
         filename = "{0}.py".format(filename)
 
-    if filename in default_settings.SETTINGS_FILE_FOR_DYNACONF:
-        silent = True
     mod = types.ModuleType(filename.rstrip(".py"))
     mod.__file__ = filename
     mod._is_error = False
@@ -124,6 +122,8 @@ def import_from_filename(obj, filename, silent=False):  # pragma: no cover
         ) as config_file:
             exec(compile(config_file.read(), filename, "exec"), mod.__dict__)
     except IOError as e:
+        if not silent:
+            raise
         e.strerror = ("py_loader: error loading file (%s %s)\n") % (
             e.strerror,
             filename,


### PR DESCRIPTION
Making errors visible when silent=False
fixes #310

```
➜  dynaconf git:(master) ✗ ls -al | grep fao 
-rw-------.  1 root    root        0 Mar 10 21:39 fao.py
```
```python
In [1]: import errno

In [2]: import io

In [3]: try:
   ...:     io.open('fao.py')
   ...: except IOError as e:
   ...:     print(e.errno)
   ...:     print(e.strerror)
   ...:     
13
Permission denied

In [4]: errno.EPERM
Out[4]: 1

In [5]: errno.EACCES
Out[5]: 13
```