### PR TITLE
Add support for aliased configs

### DIFF
--- a/dynaconf/contrib/django_dynaconf/dynaconf_django_conf.py
+++ b/dynaconf/contrib/django_dynaconf/dynaconf_django_conf.py
@@ -1,4 +1,4 @@
-# WARNING: THIS EXTENSION IS DEPRECATED
+# WARNING: THIS EXTENSION IS DEPRECATED in favor of django_dynaconf_v2
 # Read more on how to integrate with django on
 # https://dynaconf.readthedocs.io/en/latest/guides/django.html
 import os
@@ -7,20 +7,15 @@ from django.conf import settings as django_settings
 
 from dynaconf import LazySettings
 
-
 dj = {}
+
 for key in dir(django_settings):
     if key.isupper() and key != "SETTINGS_MODULE":
         dj[key] = getattr(django_settings, key, None)
     dj["ORIGINAL_SETTINGS_MODULE"] = django_settings.SETTINGS_MODULE
 
-
-dj.setdefault("ENVVAR_PREFIX_FOR_DYNACONF", "DJANGO")
-
-env_prefix = f"{dj['ENVVAR_PREFIX_FOR_DYNACONF']}_ENV"  # DJANGO_ENV
-
-dj.setdefault(
-    "ENV_FOR_DYNACONF", os.environ.get(env_prefix, "DEVELOPMENT").upper()
-)
+dj.setdefault("ENVVAR_PREFIX", "DJANGO")
+env_prefix = f"{dj['ENVVAR_PREFIX']}_ENV"  # DJANGO_ENV
+dj.setdefault("ENV", os.environ.get(env_prefix, "DEVELOPMENT").upper())
 
 settings = LazySettings(**dj)

--- a/dynaconf/contrib/flask_dynaconf.py
+++ b/dynaconf/contrib/flask_dynaconf.py
@@ -63,8 +63,8 @@ class FlaskDynaconf(object):
         app = Flask(__name__)
         FlaskDynaconf(
             app,
-            ENV_FOR_DYNACONF='MYSITE',
-            SETTINGS_FILE_FOR_DYNACONF='settings.yml',
+            ENV='MYSITE',
+            SETTINGS_FILE='settings.yml',
             EXTRA_VALUE='You can add aditional config vars here'
         )
 
@@ -87,11 +87,9 @@ class FlaskDynaconf(object):
             )
         self.kwargs = kwargs
 
-        kwargs.setdefault("ENVVAR_PREFIX_FOR_DYNACONF", "FLASK")
-
-        env_prefix = f"{kwargs['ENVVAR_PREFIX_FOR_DYNACONF']}_ENV"  # FLASK_ENV
-
-        kwargs.setdefault("ENV_SWITCHER_FOR_DYNACONF", env_prefix)
+        kwargs.setdefault("ENVVAR_PREFIX", "FLASK")
+        env_prefix = f"{kwargs['ENVVAR_PREFIX']}_ENV"  # FLASK_ENV
+        kwargs.setdefault("ENV_SWITCHER", env_prefix)
 
         self.dynaconf_instance = dynaconf_instance
         self.instance_relative_config = instance_relative_config

--- a/example/compat.py
+++ b/example/compat.py
@@ -72,9 +72,9 @@ print(settings.FRESH_VARS_FOR_DYNACONF)
 
 
 settings = LazySettings(
-    NAMESPACE_FOR_DYNACONF="FOO",
+    NAMESPACE="FOO",
     SETTINGS_MODULE="foo.py",
-    PROJECT_ROOT_FOR_DYNACONF="/tmp",
+    PROJECT_ROOT="/tmp",
     DYNACONF_SILENT_ERRORS=True,
     DYNACONF_ALWAYS_FRESH_VARS=["BAR"],
 )

--- a/example/validators/with_python/conf.py
+++ b/example/validators/with_python/conf.py
@@ -1,7 +1,7 @@
 from dynaconf import LazySettings
 from dynaconf import Validator
 
-settings = LazySettings(ENV_FOR_DYNACONF="EXAMPLE")
+settings = LazySettings(ENV="EXAMPLE")
 
 settings.validators.register(
     Validator("VERSION", "AGE", "NAME", must_exist=True),

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -739,3 +739,38 @@ def test_preload(tmpdir):
         "github": "rochacbruno.github.io",
         "mastodon": "mastodon.social/@rochacbruno",
     }
+
+
+def test_config_aliases(tmpdir):
+    data = {
+        "hello": {"name": "Bruno", "passwd": 1234},
+        "awesome": {"passwd": 5678},
+    }
+    toml_loader.write(str(tmpdir.join("blarg.toml")), data, merge=False)
+
+    settings = LazySettings(
+        ENVVAR_PREFIX="BRUCE",
+        CORE_LOADERS=["TOML"],
+        LOADERS=["dynaconf.loaders.env_loader"],
+        DEFAULT_ENV="hello",
+        ENV_SWITCHER="BRUCE_ENV",
+        PRELOAD=[],
+        SETTINGS_FILE=["blarg.toml"],
+        INCLUDES=[],
+        ENV="awesome",
+    )
+
+    assert settings.NAME == "Bruno"
+    assert settings.PASSWD == 5678
+
+    assert settings.ENVVAR_PREFIX_FOR_DYNACONF == "BRUCE"
+    assert settings.CORE_LOADERS_FOR_DYNACONF == ["TOML"]
+    assert settings.LOADERS_FOR_DYNACONF == ["dynaconf.loaders.env_loader"]
+    assert len(settings._loaders) == 1
+    assert settings.DEFAULT_ENV_FOR_DYNACONF == "hello"
+    assert settings.ENV_SWITCHER_FOR_DYNACONF == "BRUCE_ENV"
+    assert settings.PRELOAD_FOR_DYNACONF == []
+    assert settings.SETTINGS_FILE_FOR_DYNACONF == ["blarg.toml"]
+    assert settings.INCLUDES_FOR_DYNACONF == []
+    assert settings.ENV_FOR_DYNACONF == "awesome"
+    assert settings.current_env == "awesome"


### PR DESCRIPTION
Now when creating a `LazySettings` instance one can use aliases

So instead of `LazySettings("ENV_FOR_DYNACONF='FOO'")` it can be:

`LazySettings(ENV="FOO")`