### PR TITLE
Fix #272 allow lowercase keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ test_examples:
 	cd example/toml_with_secrets/;pwd;python program.py
 	cd example/envs;pwd;python app.py
 	cd example/envless_mode;pwd;python app.py
+	cd example/lower_read;pwd;python app.py
 	cd example/custom_loader;pwd;python app.py
 	cd example/get_fresh;pwd;python app.py
 	cd example/includes;pwd;python app.py

--- a/docs/guides/advanced_usage.md
+++ b/docs/guides/advanced_usage.md
@@ -17,7 +17,7 @@ Now you want to use Dynaconf, open that `conf.py` or `conf/__init__.py` and do:
 # coding: utf-8
 from dynaconf import LazySettings
 
-config = LazySettings(ENVVAR_PREFIX_FOR_DYNACONF="MYPROGRAM")
+config = LazySettings(envvar_prefix="MYPROGRAM")
 ```
 
 Now you can use `export MYPROGRAM_FOO=bar` instead of `DYNACONF_FOO=bar`
@@ -250,9 +250,9 @@ The environment variables wins precedence over all!
 
 # load dynaconf
 settings = LazySettings(
-    ENVVAR_PREFIX_FOR_DYNACONF=ENVVAR_PREFIX_FOR_DYNACONF,
-    ENVVAR_FOR_DYNACONF=ENVVAR_FOR_DYNACONF,
-    ENV_SWITCHER_FOR_DYNACONF=ENV_SWITCHER_FOR_DYNACONF
+    envvar_prefix=ENVVAR_PREFIX_FOR_DYNACONF,
+    envvar=ENVVAR_FOR_DYNACONF,
+    env_switcher=ENV_SWITCHER_FOR_DYNACONF
 )
 ```
 
@@ -288,9 +288,9 @@ Useful for plugin based apps.
 from dynaconf import LazySettings
 
 settings = LazySettings(
-  PRELOAD_FOR_DYNACONF=["/path/*", "other/settings.toml"],                # <-- Loaded first
-  SETTINGS_FILE_FOR_DYNACONF="/etc/foo/settings.py",                      # <-- Loaded second (the main file)
-  INCLUDES_FOR_DYNACONF=["other.module.settings", "other/settings.yaml"]  # <-- Loaded at the end
+  preload=["/path/*", "other/settings.toml"],                # <-- Loaded first
+  settings_file="/etc/foo/settings.py",                      # <-- Loaded second (the main file)
+  includes=["other.module.settings", "other/settings.yaml"]  # <-- Loaded at the end
 )
 
 ```

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -14,9 +14,9 @@ Or when using your own Dynaconf instance you can pass as parameters directly:
 ```py
 from dynaconf import LazySettings
 settings = LazySettings(
-    DEBUG_LEVEL_FOR_DYNACONF='DEBUG',
-    ENVVAR_PREFIX_FOR_DYNACONF='MYPROGRAM',
-    ENVVAR_FOR_DYNACONF='MYPROGRAM_SETTINGS',
+    debug_level='DEBUG',
+    envvar_prefix='MYPROGRAM',
+    envvar='MYPROGRAM_SETTINGS',
 )
 ```
 
@@ -42,13 +42,14 @@ It can also be passed as parameters to extensions like `FlaskDynaconf` or set in
     ENV | str | Working environment. | “development” | ENV_FOR_DYNACONF=production
     *FORCE_ENV | str | Force the working environment | None | FORCE_ENV_FOR_DYNACONF=other
     ENV_SWITCHER | str | Variable used to change working env. | ENV_FOR_DYNACONF | ENV_SWITCHER_FOR_DYNACONF=MYPROGRAM_ENV
-    ENVLESS_MODE | str | Ignore env layering and load everything from file. | ENVLESS_MODE | ENVLESS_MODE_FOR_DYNACONF=true
+    ENVLESS_MODE | bool | Ignore env layering and load everything from file. | False | ENVLESS_MODE_FOR_DYNACONF=true
     ENVVAR | str | The envvar which holds the list of settings files. | ‘SETTINGS_FILE_FOR_DYNACONF’ | ENVVAR_FOR_DYNACONF=MYPROGRAM_SETTINGS
     ENVVAR_PREFIX | str | Prefix for exporting parameters as env vars. Example: If your program is called *MYPROGRAM* you may want users to use *MYPROGRAM_FOO=bar* instead of *DYNACONF_FOO=bar* on envvars. | “DYNACONF” | ENVVAR_PREFIX_FOR_DYNACONF=MYPROGRAM (loads MYPROGRAM_VAR) ENVVAR_PREFIX_FOR_DYNACONF=’’ (loads _VAR) ENVVAR_PREFIX_FOR_DYNACONF=false (loads VAR)
     FRESH_VARS | list | A list of vars to be re-loaded on every access. | [] | FRESH_VARS_FOR_DYNACONF=[“HOST”, “PORT”]
     INCLUDES | list | A list of paths or a glob to load can be a toml-like list, or sep by , or ; | [] | INCLUDES_FOR_DYNACONF=”[‘path1.ext’, ‘folder/*’]” INCLUDES_FOR_DYNACONF=”path1.toml;path2.toml” INCLUDES_FOR_DYNACONF=”path1.toml,path2.toml” INCLUDES_FOR_DYNACONF=”single_path.toml” INCLUDES_FOR_DYNACONF=”single_path/glob/.toml”
     INSTANCE **used only by** *$dynaconf** *cli*. | str | Custom instance of LazySettings Must be an importable Python module. | None | INSTANCE_FOR_DYNACONF=myapp.settings
     LOADERS | list | A list of enabled external loaders. |	[‘dynaconf.loaders.env_loader’] | LOADERS_FOR_DYNACONF=’[‘module.mycustomloader’, …]’
+    LOWERCASE_READ | bool | If True first level keys can be accessed via lower case attrs |	False | LOWERCASE_READ_FOR_DYNACONF=true
     MERGE_ENABLED | bool | A bool to activate the global merge feature | False | MERGE_ENABLED_FOR_DYNACONF=1
     NESTED_SEPARATOR | str | Separator for nested assignment like `export DYNACONF_DATABASES__NAME='foo'` | `__` double underline | NESTED_SEPARATOR_FOR_DYNACONF='___'
     PRELOAD | list | A list of paths or glob to be pre-loaded before main settings file. | [] | PRELOAD_FOR_DYNACONF="['path1.ext', 'folder/*']"

--- a/dynaconf/loaders/base.py
+++ b/dynaconf/loaders/base.py
@@ -63,8 +63,6 @@ class BaseLoader(object):
         else:  # it is already a list/tuple
             files = filename
 
-        self.obj._loaded_files.extend(files)
-
         source_data = self.get_source_date(files)
 
         if self.obj.get("ENVLESS_MODE_FOR_DYNACONF") is True:
@@ -87,6 +85,7 @@ class BaseLoader(object):
                         ),
                     ) as open_file:
                         content = self.file_reader(open_file)
+                        self.obj._loaded_files.append(source_file)
                         if content:
                             data[source_file] = content
                             self.obj.logger.debug(

--- a/example/lower_read/app.py
+++ b/example/lower_read/app.py
@@ -1,0 +1,12 @@
+from dynaconf import LazySettings
+
+settings = LazySettings(envless_mode=True, lowercase_read=True)
+
+assert settings.server == "foo.com"
+assert settings.SERVER == "foo.com"
+assert settings["SERVER"] == "foo.com"
+assert settings["server"] == "foo.com"
+assert settings("SERVER") == "foo.com"
+assert settings("server") == "foo.com"
+assert settings.get("SERVER") == "foo.com"
+assert settings.get("server") == "foo.com"

--- a/example/lower_read/settings.yaml
+++ b/example/lower_read/settings.yaml
@@ -1,0 +1,2 @@
+server: foo.com
+port: 8080

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -791,3 +791,27 @@ def test_envless_mode(tmpdir):
     assert settings.HELLO == "world"
     assert settings.DEFAULT == 1
     assert settings.DATABASES.default.port == 8080
+
+
+def test_lowercase_read_mode(tmpdir):
+    data = {
+        "foo": "bar",
+        "hello": "world",
+        "default": 1,
+        "databases": {"default": {"port": 8080}},
+    }
+    toml_loader.write(str(tmpdir.join("settings.toml")), data)
+
+    settings = LazySettings(ENVLESS_MODE=True, lowercase_read=True)
+
+    assert settings.FOO == "bar"
+    assert settings.foo == "bar"
+    assert settings.HELLO == "world"
+    assert settings.hello == "world"
+    assert settings.DEFAULT == 1
+    assert settings.default == 1
+    assert settings.DATABASES.default.port == 8080
+    assert settings.Databases.default.port == 8080
+
+    assert "foo" in settings
+    assert "FOO" in settings


### PR DESCRIPTION
Fix #272 allow access of lowercase keys

- `settings.lowercase_key` is allowed
- `settings.dynaconf` is a proxy to internal methods
- `settings.__reserved_attributes` validates key names
- `LazySettings __init__ parameters can receive lower case configs`