### PR TITLE
Fix validation of optional fields

### DIFF
--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -184,6 +184,8 @@ class Validator(object):
                 )
             elif self.must_exist is False and not exists:
                 return
+            elif self.must_exist is None and not exists:
+                return
 
             value = self.cast(settings.get(name, empty))
 

--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -182,9 +182,7 @@ class Validator(object):
                         name=name, env=env
                     )
                 )
-            elif self.must_exist is False and not exists:
-                return
-            elif self.must_exist is None and not exists:
+            elif self.must_exist in (False, None) and not exists:
                 return
 
             value = self.cast(settings.get(name, empty))


### PR DESCRIPTION
# The problem

According to the documentation (https://www.dynaconf.com/validation/) Validator should treat all fields as optional unless `must_exist` option is set, but it doesn't work as expected. 
In the example below we have optional setting `optional_settings` in config but validator fails with error if this setting is not present:

```
Traceback (most recent call last):
  File "test.py", line 15, in <module>
    settings.validators.validate()
  File "/Users/piotr/Documents/Repos/dynaconf/dynaconf/validator.py", line 288, in validate
    validator.validate(self.settings)
  File "/Users/piotr/Documents/Repos/dynaconf/dynaconf/validator.py", line 163, in validate
    self._validate_items(settings, settings.current_env)
  File "/Users/piotr/Documents/Repos/dynaconf/dynaconf/validator.py", line 208, in _validate_items
    raise ValidationError(
dynaconf.validator.ValidationError: app.optional_settings must is_type_of <class 'bool'> but it is EMPTY in env main
``` 

# Test case:

```yaml
# settings.yaml
app:
  # optional_settings: True
  other: "setting"
```

```python
# test.py
from dynaconf import Dynaconf
from dynaconf import Validator

settings = Dynaconf(
    settings_files=["settings.yaml"],
    environments=False,
    load_dotenv=True
)

print(settings.app)

settings.validators.register(
    Validator('app.optional_settings', is_type_of=bool, must_exist=None)
)
settings.validators.validate() # << throw error
```

This PR fixes this issue.