### PR TITLE
Allow importing SEARCHTREE before settings are configured

### DIFF
--- a/dynaconf/utils/files.py
+++ b/dynaconf/utils/files.py
@@ -28,7 +28,7 @@ def _walk_to_root(path, break_at=None):
     return paths
 
 
-SEARCHTREE = None
+SEARCHTREE = []
 
 
 def find_file(filename=".env", project_root=None, skip_files=None, **kwargs):
@@ -63,7 +63,7 @@ def find_file(filename=".env", project_root=None, skip_files=None, **kwargs):
     search_tree = deduplicate(search_tree)
 
     global SEARCHTREE
-    SEARCHTREE = search_tree
+    SEARCHTREE[:] = search_tree
 
     for dirname in search_tree:
         check_path = os.path.join(dirname, filename)


### PR DESCRIPTION
Hello,

I am a fairly new user of dynaconf (it's an awesome package btw 💖 🙇  ) and I ran into an issue where I wanted to display the search tree to the user so that they understand where they can place their config files so that they are discovered. I imported `SEARCHTREE` before settings were configured and then it won't update after they are. This commit fixes this minor issue...

<br>

Currently: if `dynaconf.utils.files.SEARCHTREE` is imported before settings are configured, it stays `None`.

This commit allows usercode to import `SEARCHTREE` before dynaconf is configured, and have it be updated as soon as it is.

```python
from dynaconf import Dynaconf
from dynaconf.utils.files import SEARCHTREE

settings = DynaConf(...)

# after settings are configured SEARCHTREE is updated
settings.configure()

```

**NOTE:** this is a potentially breaking change if any usercode relies on a `ìf SEARCHTREE is None` test instead.


Cheers,
Andreas 😃 