### PR TITLE
Fix #377 allow default and computed values

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -55,6 +55,50 @@ settings = Dynaconf(
 
 The above will raise `dynaconf.validators.ValidationError("AGE must be lte=30 but it is 35 in env DEVELOPMENT")` and `dynaconf.validators.ValidationError("PROJECT must be eq='hello_world' but it is 'This is not hello_world' in env PRODUCTION")`
 
+
+### Providing default or computed values
+
+
+Validators can be used to provide default or computed values.
+
+#### Defeault values
+
+```py
+Validator("FOO", default="A default value for foo")
+```
+
+Then if not able to load the values from files or environment this default value will be set for that key.
+
+
+#### Computed values
+
+Sometimes you need some values to be computed by calling functions, just passa a callable to the `default` argument.
+
+```py
+
+Validator("FOO", default=my_dunction)
+
+```
+
+then
+
+```py
+
+def my_function(settings, validator):
+    return "this is computed during validation time"
+
+```
+
+If you want to be lazy evaluated
+
+```py
+
+from dynaconf.utils.parse_conf import empty, Lazy
+
+Validator("FOO", default=Lazy(empty, formatter=my_function))
+
+```
+
 You can also use dot-delimited paths for registering validators on nested structures:
 
 ```python

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -234,7 +234,7 @@ class Settings(object):
         self._env_cache = {}
         self._loaded_by_loaders = {}
         self._loaders = []
-        self._defaults = {}
+        self._defaults = DynaBox(box_settings=self)
         self.environ = os.environ
         self.SETTINGS_MODULE = None
         self._not_installed_warnings = []
@@ -319,6 +319,20 @@ class Settings(object):
     def values(self):
         """Redirects to store object"""
         return self.store.values()
+
+    def setdefault(self, item, default):
+        """Returns value if exists or set it as the given default"""
+        value = self.get(item, empty)
+        if value is empty and default is not empty:
+            self.set(
+                item,
+                default,
+                loader_identifier="setdefault",
+                tomlfy=True,
+                dotted_lookup=True,
+            )
+            return default
+        return value
 
     def as_dict(self, env=None, internal=False):
         """Returns a dictionary with set key and values.

--- a/example/issues/377_default_validators/app.py
+++ b/example/issues/377_default_validators/app.py
@@ -1,0 +1,42 @@
+from dynaconf import Dynaconf
+from dynaconf import Validator
+
+
+settings = Dynaconf(
+    validators=[Validator("COMPUTED", default=lambda st, va: "I am computed")]
+)
+
+
+assert settings.COMPUTED == "I am computed"
+
+settings2 = Dynaconf(
+    settings_file="settings.toml",
+    environments=True,
+    validators=[
+        Validator(
+            "FOO",
+            env="production",
+            default=lambda st, va: "FOO is computed in prod",
+        ),
+        Validator("BAR", env="production", default="@format {this.foo}/BAR"),
+        Validator(
+            "ZAZ", env="production", default="@jinja {{this.get('foo')}}/ZAZ"
+        ),
+        Validator("FOO", env="development", required=True, eq="dev foo"),
+    ],
+)
+
+assert settings2.FOO == "dev foo"
+assert settings2.get("FOO") == "dev foo"
+assert settings2["FOO"] == "dev foo"
+assert settings2.foo == "dev foo"
+assert settings2("foo") == "dev foo"
+
+assert settings2.from_env("production").FOO == "FOO is computed in prod"
+assert settings2.from_env("production").foo == "FOO is computed in prod"
+assert settings2.from_env("production")["FOO"] == "FOO is computed in prod"
+assert settings2.from_env("production")("FOO") == "FOO is computed in prod"
+assert settings2.from_env("production").get("FOO") == "FOO is computed in prod"
+
+assert settings2.from_env("production").BAR == "FOO is computed in prod/BAR"
+assert settings2.from_env("production").ZAZ == "FOO is computed in prod/ZAZ"

--- a/example/issues/377_default_validators/settings.toml
+++ b/example/issues/377_default_validators/settings.toml
@@ -1,0 +1,5 @@
+[development]
+FOO = "dev foo"
+
+[production]
+# here FOO is computed

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -427,3 +427,25 @@ def test_cast_before_validate(tmpdir):
     )
     assert settings.name == "Bruno"
     assert settings.colors == ["red", "green", "blue"]
+
+
+def test_validator_can_provide_default(tmpdir):
+    tmpfile = tmpdir.join("settings.toml")
+    TOML = """
+    name = 'Bruno'
+    colors = ['red', 'green', 'blue']
+    """
+    tmpfile.write(TOML)
+    settings = LazySettings(
+        settings_file=str(tmpfile),
+        validators=[
+            Validator("name", required=True),
+            Validator("FOO", default="BAR"),
+            Validator("COMPUTED", default=lambda st, va: "I am computed"),
+        ],
+    )
+    assert settings.name == "Bruno"
+    assert settings.colors == ["red", "green", "blue"]
+
+    assert settings.FOO == "BAR"
+    assert settings.COMPUTED == "I am computed"


### PR DESCRIPTION
Fix #377 


### Providing default or computed values


Validators can be used to provide default or computed values.

#### Defeault values

```py
Validator("FOO", default="A default value for foo")
```

Then if not able to load the values from files or environment this default value will be set for that key.


#### Computed values

Sometimes you need some values to be computed by calling functions, just passa a callable to the `default` argument.

```py

Validator("FOO", default=my_dunction)

```

then

```py

def my_function(settings, validator):
    return "this is computed during validation time"

```

If you want to be lazy evaluated

```py

from dynaconf.utils.parse_conf import empty, Lazy

Validator("FOO", default=Lazy(empty, formatter=my_function))

```