### PR TITLE
Fix typo in Validation docs

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -76,7 +76,7 @@ Sometimes you need some values to be computed by calling functions, just passa a
 
 ```py
 
-Validator("FOO", default=my_dunction)
+Validator("FOO", default=my_function)
 
 ```
 


### PR DESCRIPTION
There was a typo in the function name. This fixes it.