### PR TITLE
docs: Fixed filename error in the case of the index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ pip install dynaconf
         from dynaconf import Dynaconf
 
         settings = Dynaconf(
-            settings_files=['settings.yaml', '.secrets.yaml'],
+            settings_files=['settings.toml', '.secrets.toml'],
         )
         ```
         More options described on [Dynaconf Configuration](/configuration/)


### PR DESCRIPTION
[The Initialize Dynaconf on your project](https://www.dynaconf.com/#initialize-dynaconf-on-your-project) use `dynaconf init -f toml` to generate.toml files, but yaml files are used in the Initialize code `config.py`, which is an obvious error and confuses the reader.