### PR TITLE
Correct typos in documentation and README

### DIFF
--- a/3.x-release-notes.md
+++ b/3.x-release-notes.md
@@ -16,7 +16,7 @@ Some of the changes were discussed on the **1st Dynaconf community meeting** [vi
 - Added implementation for `__dir__` to allow auto complete for terminal and IDEs.
 - Add option to override mount point for vault server.
 - `LazySettings` is now aliased to `Dynaconf`
-- `Dynaconf` class now accepts a parameter `validators=[Validator, ...]` that will be immediatelly evaluated when passed.
+- `Dynaconf` class now accepts a parameter `validators=[Validator, ...]` that will be immediately evaluated when passed.
 
 ## Breaking Changes
 
@@ -140,7 +140,7 @@ settings = Dynaconf(
 
 BY default it keeps searching for files in the current `PROJECT_ROOT` named `.env` and the `dotenv_path` accepts a relative path such as `.env` or  `path/to/.env`
 
-#### DEBUG Logging is now completelly removed
+#### DEBUG Logging is now completely removed
 
 There is no more `logging` or `debug` messages being printed, so the variable `DEBUG_LEVEL` has no more effect.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - Built-in support for Hashicorp Vault and Redis as settings and secrets storage.
 - Built-in extensions for **Django** and **Flask** web frameworks.
 - CLI for common operations such as `init, list, write, validate, export`.
-- fuill docs on https://dynaconf.com
+- full docs on https://dynaconf.com
 
 ## Quick start
 
@@ -87,7 +87,7 @@ Put sensitive information on `.secrets.{toml|yaml|ini|json|py}`
 password = "secret123"
 ```
 
-> **IMPORTANT:** `dynaconf init` command puts the `.secrets.*` in yout `.gitignore` to avoid it to be exposed on public repos but it is your responsibility to keep it safe in your local environment, also the recommendation for production environments is to use the built-in support for Hashicorp Vault service for password and tokens.
+> **IMPORTANT:** `dynaconf init` command puts the `.secrets.*` in your `.gitignore` to avoid it to be exposed on public repos but it is your responsibility to keep it safe in your local environment, also the recommendation for production environments is to use the built-in support for Hashicorp Vault service for password and tokens.
 
 
 Optionally you can now use environment variables to override values per execution or per environment.
@@ -118,7 +118,7 @@ settings['databases.schema'] == "main"  # Nested key traversing
 - Settings Schema Validation
 - Custom Settings Loaders
 - Vault Services
-- Template substitions
+- Template substitutions
 - etc...
 
 There is a lot more you can do, **read the docs:** http://dynaconf.com

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -199,7 +199,7 @@ assert settings.MESSAGE == 'This is in dev'
 
 > **New in 2.0.0**
 
-You can use dynaconf values to populate Python objects (intances).
+You can use dynaconf values to populate Python objects (instances).
 
 example:
 ```py
@@ -305,7 +305,7 @@ all the tests are collected.
 
 Examples available on [https://github.com/rochacbruno/dynaconf/tree/master/example/pytest_example](https://github.com/rochacbruno/dynaconf/tree/master/example/pytest_example)
 
-With `pytest` fixtures it is recommended to use the `FORCE_ENV_FOR_DYNACONF` isntead of just `ENV_FOR_DYNACONF` because it has precedence.
+With `pytest` fixtures it is recommended to use the `FORCE_ENV_FOR_DYNACONF` instead of just `ENV_FOR_DYNACONF` because it has precedence.
 
 #### A python program
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -171,7 +171,7 @@ Options:
 
 > **NEW in 1.0.1**
 
-Starting on version 1.0.1 it is possible to define validators in **TOML** file called **dynaconf_validators.toml** placed in the same fodler as your settings files.
+Starting on version 1.0.1 it is possible to define validators in **TOML** file called **dynaconf_validators.toml** placed in the same folder as your settings files.
 
 `dynaconf_validators.toml` equivalent to program above
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,7 @@ When `load_dotenv` is enabled, this controls if variables in `.env` will overrid
 
 ### **dotenv_path**
 
-Sets the path for the `.env` file and it can be full path ot just the directory.
+Sets the path for the `.env` file and it can be full path or just the directory.
 
 - type: str
 - default: "." (or the same as project_root)
@@ -214,7 +214,7 @@ The list of loaders Dynaconf will trigger after its core loaders, this list is u
 [custom loaders](/advanced/#custom loaders) and also to control the loading of env vars as the last step.
 
 !!! warning
-    By default the `env_loader` will be latest on this list, so it ensures anvironment variables has
+    By default the `env_loader` will be latest on this list, so it ensures environment variables has
     the priority following the Unix philosophy.
 
 - type: list
@@ -380,7 +380,7 @@ Must be a `list`:
 settings_files=["file1.toml", "file2.toml"]
 ```
 
-or a `str` separated by semicollons or commas.
+or a `str` separated by semicolons or commas.
 
 ```py
 settings_files="file1.toml;file2.toml"
@@ -423,7 +423,7 @@ skip_filess=["path/to/ignored.toml"]
 
 ### **validators**
 
-A list of validators to be trigered right after the `Dynaconf` initialization.
+A list of validators to be triggered right after the `Dynaconf` initialization.
 
 - type: list
 - default: []

--- a/docs/django.md
+++ b/docs/django.md
@@ -46,7 +46,7 @@ export DJANGO_INTVALUE=1     # django.conf.settings['INTVALUE']
 export DJANGO_HELLO="Hello"  # django.conf.settings.get('HELLO')
 ```
 
-> **TIP**: If you dont want to use `DJANGO_` as prefix for envvars you can customize by passing a new name e.g: `dynaconf.DjangoDynaconf(__name__, ENVVAR_PREFIX_FOR_DYNACONF="FOO")` then `export FOO_DEBUG=true`
+> **TIP**: If you don't want to use `DJANGO_` as prefix for envvars you can customize by passing a new name e.g: `dynaconf.DjangoDynaconf(__name__, ENVVAR_PREFIX_FOR_DYNACONF="FOO")` then `export FOO_DEBUG=true`
 
 You can also set nested dictionary values, for example lets say you have a configuration like this:
 
@@ -138,13 +138,13 @@ Working environment can now be switched using `export PROJECTNAME_ENV=production
 
 Your settings are now read from `/etc/projectname/settings.toml` (dynaconf will not perform search for all the settings formats). This settings location can be changed via envvar using `export PROJECTNAME_SETTINGS=/other/path/to/settings.py{yaml,toml,json,ini}`
 
-You can have additional settings read from `/etc/projectname/plugins/*` any supoprted file from this folder will be loaded.
+You can have additional settings read from `/etc/projectname/plugins/*` any supported file from this folder will be loaded.
 
 You can set more options, take a look on [configuration](/configuration/)
 
 ## Reading Settings on Standalone Scripts
 
-> **NOTE**: The recommended way to create standalone scripts is by creating `management commands` inside your Django applications or pugins.
+> **NOTE**: The recommended way to create standalone scripts is by creating `management commands` inside your Django applications or plugins.
 
 > **IMPORTANT** If you need that script to be out of your Django Application Scope, it is also possible and **if needed** you can use `settings.DYNACONF.configure()` instead of the common `settings.configure()` provided by Django.
 
@@ -254,9 +254,9 @@ settings.populate_obj(sys.modules[__name__], ignore=locals())
 
 > **NOTE**: Starting in `2.1.1` the `ignore` argument will tell Dynaconf to not override variables that already exists in the current settings file, remove it if you want all the existing local variables to be overwritten by dynaconf.
 
-You can still change env with `export DJANGO_ENV=production` and also can export variables lile `export DJANGO_DEBUG=true`
+You can still change env with `export DJANGO_ENV=production` and also can export variables like `export DJANGO_DEBUG=true`
 
-## Knowm Caveats
+## Known Caveats
 
 - If `settings.configure()` is called directly it disables Dynaconf, use `settings.DYNACONF.configure()`
 

--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -34,7 +34,7 @@ DB_PATH = "@format {env[HOME]}/{this.current_env}/{env[PROGRAM_NAME]}/{this.DB_N
 - `{env[HOME]}` is the same as `os.environ["HOME"]` or `$HOME` in the shell.
 - `{this.current_env}` is the same as `settings.current_env`
 - `{env[PROGRAM_NAME]}` is the same as `os.environ["PROGRAM_NAME"]` or `$PROGRAM_NAME` in the shell.
-- `{this.DB_NAME}` is the same as `settins.DB_NAME` or `settings["DB_NAME"]`
+- `{this.DB_NAME}` is the same as `settings.DB_NAME` or `settings["DB_NAME"]`
 
 so in your `program`
 

--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -72,6 +72,6 @@ from dynaconf import settings
 settings.DB_PATH == '~/development/calculator/mydb.db'
 ```
 
-The main difference is that Jinja allows some Python expressions to be avaluated such as `{% for, if, while %}` and also supports calling methods and has lots of filters like `| lower`.
+The main difference is that Jinja allows some Python expressions to be evaluated such as `{% for, if, while %}` and also supports calling methods and has lots of filters like `| lower`.
 
-Jinja supports its built-in filters listed in [Builtin Filters Page](http://jinja.palletsprojects.com/en/master/templates/#builtin-filters) and Dynaconf includes aditional filters for `os.path` module: `abspath`. `realpath`, `relpath`, `basename` and `dirname` and usage is like: `VALUE = "@jinja {{this.FOO | abspath}}"`
+Jinja supports its built-in filters listed in [Builtin Filters Page](http://jinja.palletsprojects.com/en/master/templates/#builtin-filters) and Dynaconf includes additional filters for `os.path` module: `abspath`. `realpath`, `relpath`, `basename` and `dirname` and usage is like: `VALUE = "@jinja {{this.FOO | abspath}}"`

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -51,7 +51,7 @@ assert settings.STRING_NUM == "76"
 
 !!! tip
     Dynaconf has multiple valid ways to access settings keys so it is compatible with your 
-    existing settings solution. You can acess using `.notation`, `[item] indexing`, `.get method` 
+    existing settings solution. You can access using `.notation`, `[item] indexing`, `.get method` 
     and also it allows `.notation.nested` for data structures like dicts.  
     **Also variable access is case insensitive for the first level key**
 

--- a/docs/flask.md
+++ b/docs/flask.md
@@ -71,7 +71,7 @@ app = Flask(__name__)
 flask_dynaconf = FlaskDynaconf(app, extensions_list="EXTENSIONS")
 ```
 
-The above will immediatelly load all flask extensions listed on `EXTENSIONS` key on settings.
+The above will immediately load all flask extensions listed on `EXTENSIONS` key on settings.
 
 You can also load it lazily.
 
@@ -92,7 +92,7 @@ export FLASK_EXTENSIONS="['flask_admin:Admin']"
 The extensions will be loaded in order.
 
 
-### Develoment extensions
+### Development extensions
 
 It is also possible to have extensions that loads only for development environment.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -362,7 +362,7 @@ you can optionally store settings in [Settings Files](/settings_files/) using an
 
 [environment variables](/envvars/) are loaded by Dynaconf if prefixed either with
 `DYNACONF_` or a `CUSTOM_` name that you can customize on your settings instance, or
-`FLASK_` and `DJANGO_` respectivelly if you are using extensions.
+`FLASK_` and `DJANGO_` respectively if you are using extensions.
 
 ```bash
 export DYNACONF_FOO=BAR                      # string value
@@ -398,7 +398,7 @@ mixed settings formats across your application.
 
 - **.toml** - Default and **recommended** file format.
 - **.yaml|.yml** - Recommended for Django applications.
-- **.json** - Usefull to reuse existing or exported settings.
+- **.json** - Useful to reuse existing or exported settings.
 - **.ini** - Useful to reuse legacy settings.
 - **.py** - **Not Recommended** but supported for backwards compatibility.
 - **.env** - Useful to automate the loading of environment variables.
@@ -530,10 +530,10 @@ You can for example name it `[testing]` or `[anything]`
 !!! warning
     On **Flask** and **Django** extensions the default behaviour is already
     the layered environments.
-    Also to switch the environment you use `#!bash export FLASK_ENV=production` or `#!bash export DJANGO_ENV=production` respectivelly. 
+    Also to switch the environment you use `#!bash export FLASK_ENV=production` or `#!bash export DJANGO_ENV=production` respectively. 
 
 !!! tip
-    It is also possible to switch environments programatically passing
+    It is also possible to switch environments programmatically passing
     `env="development"` to `Dynaconf` class on instantiation.
 
 

--- a/docs/merging.md
+++ b/docs/merging.md
@@ -1,6 +1,6 @@
 ## Merging existing data structures
 
-If your settings has existing variables of types `list` ot `dict` and you want to `merge` instead of `override` then 
+If your settings has existing variables of types `list` or `dict` and you want to `merge` instead of `override` then 
 the `dynaconf_merge` and `dynaconf_merge_unique` stanzas can mark that variable as a candidate for merging.
 
 For **dict** value:

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -8,7 +8,7 @@
 
 Validators can be used to provide default or computed values.
 
-#### Defeault values
+#### Default values
 
 ```py
 Validator("FOO", default="A default value for foo")
@@ -19,7 +19,7 @@ Then if not able to load the values from files or environment this default value
 
 #### Computed values
 
-Sometimes you need some values to be computed by calling functions, just passa a callable to the `default` argument.
+Sometimes you need some values to be computed by calling functions, just pass a callable to the `default` argument.
 
 ```py
 
@@ -64,7 +64,7 @@ Some of the changes were discussed on the **1st Dynaconf community meeting** [vi
 - Added implementation for `__dir__` to allow auto complete for terminal and IDEs.
 - Add option to override mount point for vault server.
 - `LazySettings` is now aliased to `Dynaconf`
-- `Dynaconf` class now accepts a parameter `validators=[Validator, ...]` that will be immediatelly evaluated when passed.
+- `Dynaconf` class now accepts a parameter `validators=[Validator, ...]` that will be immediately evaluated when passed.
 
 ## Breaking Changes
 
@@ -188,7 +188,7 @@ settings = Dynaconf(
 
 BY default it keeps searching for files in the current `PROJECT_ROOT` named `.env` and the `dotenv_path` accepts a relative path such as `.env` or  `path/to/.env`
 
-#### DEBUG Logging is now completelly removed
+#### DEBUG Logging is now completely removed
 
 There is no more `logging` or `debug` messages being printed, so the variable `DEBUG_LEVEL` has no more effect.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -119,7 +119,7 @@ export SECRETS_FOR_DYNACONF=/path/to/secrets.toml{json|py|ini|yaml}
 If that variable exists in your environment then Dynaconf will also load it.
 
 ---
-## External Storaged
+## External Storage
 
 An external storage is needed in some programs for scenarios like:
 
@@ -190,7 +190,7 @@ DYNACONF_PRODUCTION {
 
 Then to access that values you can set `export ENV_FOR_DYNACONF=production` or directly via `settings.from_env('production').NAME`
 
-> if you want to skip type casting, write as string intead of PORT=1234 use PORT="'1234'".
+> if you want to skip type casting, write as string instead of PORT=1234 use PORT="'1234'".
 
 Data is read from redis and another loaders only once when `dynaconf.settings` is first accessed
 or when `from_env`, `.setenv()` or `using_env()` are invoked.

--- a/docs/settings_files.md
+++ b/docs/settings_files.md
@@ -12,7 +12,7 @@ mixed settings formats across your application.
 
 - **.toml** - Default and **recommended** file format.
 - **.yaml|.yml** - Recommended for Django applications.
-- **.json** - Usefull to reuse existing or exported settings.
+- **.json** - Useful to reuse existing or exported settings.
 - **.ini** - Useful to reuse legacy settings.
 - **.py** - **Not Recommended** but supported for backwards compatibility.
 - **.env** - Useful to automate the loading of environment variables.
@@ -64,7 +64,7 @@ settings.name == "Bruno"
 ```
 
 !!! info
-    The default enconding when loading the settings files is `utf-8` and it can be customized
+    The default encoding when loading the settings files is `utf-8` and it can be customized
     via `encoding` parameter.
 
 ## Settings file location
@@ -91,7 +91,7 @@ specified in `root_path`.
 
 ### /etc/program/foo.yaml
 
-Dynaconf will then recognize this as an absolute path and will try to laod it directly from
+Dynaconf will then recognize this as an absolute path and will try to load it directly from
 the specified location.
 
 
@@ -208,8 +208,8 @@ You can for example name it `[testing]` or `[anything]`
 !!! warning
     On **Flask** and **Django** extensions the default behaviour is already
     the layered environments.
-    Also to switch the environment you use `#!bash export FLASK_ENV=production` or `#!bash export DJANGO_ENV=production` respectivelly. 
+    Also to switch the environment you use `#!bash export FLASK_ENV=production` or `#!bash export DJANGO_ENV=production` respectively. 
 
 !!! tip
-    It is also possible to switch environments programatically passing
+    It is also possible to switch environments programmatically passing
     `env="development"` to `Dynaconf` class on instantiation.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -16,7 +16,7 @@ PORT = 8001
 PROJECT = "This is not hello_world"
 ```
 
-## Validating in Python programatically
+## Validating in Python programmatically
 
 At any point of your program you can do:
 
@@ -61,7 +61,7 @@ The above will raise `dynaconf.validators.ValidationError("AGE must be lte=30 bu
 
 Validators can be used to provide default or computed values.
 
-#### Defeault values
+#### Default values
 
 ```py
 Validator("FOO", default="A default value for foo")
@@ -72,7 +72,7 @@ Then if not able to load the values from files or environment this default value
 
 #### Computed values
 
-Sometimes you need some values to be computed by calling functions, just passa a callable to the `default` argument.
+Sometimes you need some values to be computed by calling functions, just pass a callable to the `default` argument.
 
 ```py
 
@@ -137,7 +137,7 @@ Validator('DATABASE.HOST', must_exist=True) & Validator('DATABASE.CONN', must_ex
 
 > **NEW in 1.0.1**
 
-Starting on version 1.0.1 it is possible to define validators in **TOML** file called **dynaconf_validators.toml** placed in the same fodler as your settings files.
+Starting on version 1.0.1 it is possible to define validators in **TOML** file called **dynaconf_validators.toml** placed in the same folder as your settings files.
 
 `dynaconf_validators.toml` equivalent to program above
 


### PR DESCRIPTION
I ran through all `.md` files with a spellchecker after finding a few small typos.

I skipped CHANGELOG.md, however.