### PR TITLE
Fix django logging conflict

### DIFF
--- a/dynaconf/utils/boxing.py
+++ b/dynaconf/utils/boxing.py
@@ -15,7 +15,7 @@ def evaluate_lazy_format(f):
         value = f(dynabox, item, *args, **kwargs)
         settings = dynabox._box_config["box_settings"]
 
-        if getattr(value, "formatter", None):
+        if getattr(value, "_dynaconf_lazy_format", None):
             dynabox._box_config[
                 f"raw_{item.lower()}"
             ] = f"@{value.formatter.token} {value.value}"


### PR DESCRIPTION
Dynaconf is trying to detect a lazy formattable value by the presence of `formatter` attribute but in Django `LOGGING` has a `.formatter` and it is going to fail.