### PR TITLE
Fix set attribute directly and fresh vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ test_examples:
 	cd example/issues/228_nested_toml_bool/python_app;pwd;python app.py
 	cd example/issues/228_nested_toml_bool/django_app;pwd;python manage.py test
 	cd example/issues/251_dotted_unexistent;pwd;python app.py
+	cd example/issues/253_set;pwd;python app.py
 	cd example/issues/266_envvar_from_env_override;pwd;python app.py
 	cd example/issues/288_null_values;pwd;python app.py
 	cd example/issues/306_merge_replace;pwd;python app.py

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -264,12 +264,12 @@ class Settings(object):
         return self.get(*args, **kwargs)
 
     def __setattr__(self, name, value):
-        """Allow `settings.FOO = 'value'` and deal with `_deleted`"""
+        """Allow `settings.FOO = 'value'` while keeping internal attrs."""
 
-        if name not in RESERVED_ATTRS + dir(default_settings):
-            self.set(name, value)
-        else:
+        if name in RESERVED_ATTRS:
             super(Settings, self).__setattr__(name, value)
+        else:
+            self.set(name, value)
 
     def __delattr__(self, name):
         """stores reference in `_deleted` for proper error management"""

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -265,12 +265,11 @@ class Settings(object):
 
     def __setattr__(self, name, value):
         """Allow `settings.FOO = 'value'` and deal with `_deleted`"""
-        try:
-            self._deleted.discard(name)
-        except AttributeError:
-            pass
 
-        super(Settings, self).__setattr__(name, value)
+        if name not in RESERVED_ATTRS + dir(default_settings):
+            self.set(name, value)
+        else:
+            super(Settings, self).__setattr__(name, value)
 
     def __delattr__(self, name):
         """stores reference in `_deleted` for proper error management"""
@@ -832,9 +831,9 @@ class Settings(object):
         if isinstance(value, dict):
             value = DynaBox(value, box_settings=self)
 
-        setattr(self, key, value)
         self.store[key] = value
         self._deleted.discard(key)
+        super(Settings, self).__setattr__(key, value)
 
         # set loader identifiers so cleaners know which keys to clean
         if loader_identifier and loader_identifier in self.loaded_by_loaders:

--- a/dynaconf/default_settings.py
+++ b/dynaconf/default_settings.py
@@ -136,7 +136,7 @@ default_redis = {
     "db": int(get("REDIS_DB_FOR_DYNACONF", 0)),
     "decode_responses": get("REDIS_DECODE_FOR_DYNACONF", True),
     "username": get("REDIS_USERNAME_FOR_DYNACONF", None),
-    "password": get("REDIS_PASSWORD_FOR_DYNACONF", None)
+    "password": get("REDIS_PASSWORD_FOR_DYNACONF", None),
 }
 REDIS_FOR_DYNACONF = get("REDIS_FOR_DYNACONF", default_redis)
 REDIS_ENABLED_FOR_DYNACONF = get("REDIS_ENABLED_FOR_DYNACONF", False)

--- a/example/issues/253_set/app.py
+++ b/example/issues/253_set/app.py
@@ -1,0 +1,37 @@
+import os
+
+from dynaconf import Dynaconf
+
+settings = Dynaconf()
+
+# first we set something
+os.environ["DYNACONF_SOMETHING"] = "this exists"
+
+settings.get("FOO")  # this is just to fire the loaders
+
+os.environ["DYNACONF_SOMETHING"] = "changed to other thing"
+
+# then we load it freshly
+assert settings.get_fresh("SOMETHING") == "changed to other thing"
+
+# then we remove it from environment
+del os.environ["DYNACONF_SOMETHING"]
+
+assert "DYNACONF_SOMETHING" not in os.environ
+
+# then we read it freshly again
+assert settings.get_fresh("SOMETHING") is None, settings.get_fresh("SOMETHING")
+
+settings.set("wm", "i3")
+
+assert settings.WM == "i3"
+
+settings.EDITOR = "vim"
+
+assert settings.get("editor") == "vim"
+
+assert settings.editor == "vim"
+
+settings.terminal_emulator = "alacritty"
+
+assert settings.get("TERMINAL_emulator") == "alacritty"

--- a/example/issues/392_evaluate_nested_structures/app.py
+++ b/example/issues/392_evaluate_nested_structures/app.py
@@ -4,7 +4,6 @@ settings = Dynaconf(
     settings_files=["settings.toml", "settings.yaml"], environments=True
 )
 
-
 assert settings.SOME_DICT.value == "formatted: foo", settings.SOME_DICT.value
 
 assert settings.INNER1.value == "inner1 str foo"


### PR DESCRIPTION
Fix #253
Fix #395

Allows `settings.FOO = 1` and fixes some fresh_vars issues