### PR TITLE
Fix #443 object merge with same value on same level keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ test_examples:
 	cd example/issues/404_dup_validator_message;pwd;python app.py
 	cd example/issues/434_setenv;pwd;python app.py --config development dynaconf
 	cd example/issues/430_same_name;pwd;python app.py
+	cd example/issues/443_object_merge;pwd;python app.py
 
 test_vault:
 	# @cd example/vault;pwd;python write.py

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -42,7 +42,11 @@ def object_merge(old, new, unique=False, full_path=None):
 
         for key, value in old.items():
 
-            if existing_value is not None and existing_value is value:
+            if (
+                existing_value is not None
+                and key == full_path[-1]
+                and existing_value is value
+            ):
                 continue
 
             if key not in new:

--- a/example/issues/443_object_merge/README.md
+++ b/example/issues/443_object_merge/README.md
@@ -1,0 +1,53 @@
+# [bug] Setting values being stripped out after merge
+
+* created by @daviddavis on 2020-10-07 14:13:58 +0000 UTC
+
+**Describe the bug**
+I'm seeing where values are being stripped out of settings. This is on dynaconf 3.1.1 with Python 3.7.7.
+
+**To Reproduce**
+Run this code:
+
+```python
+from dynaconf.utils.boxing import DynaBox
+from dynaconf.utils import object_merge
+
+existing_data = DynaBox({"DATABASES": {'default': {'ENGINE': 'django.db.backends.postgresql_psycopg2', 'HOST': 'localhost', 'PASSWORD': 'pulp', 'NAME': 'pulp', 'USER': 'pulp'}}})
+new_data = DynaBox({'DATABASES': {'default': {'USER': 'postgres'}}})
+split_keys = ['DATABASES', 'default', 'USER']
+object_merge(old=existing_data, new=new_data, full_path=split_keys)
+```
+
+The output:
+
+```
+<Box: {'DATABASES': {'default': {'USER': 'postgres', 'ENGINE': 'django.db.backends.postgresql_psycopg2', 'HOST': 'localhost'}}}>
+```
+
+Notice that NAME and PASSWORD keys have been dropped.
+
+**Expected behavior**
+I would expect the final settings dict to be:
+
+```
+{"DATABASES": {'default': {'ENGINE': 'django.db.backends.postgresql_psycopg2', 'HOST': 'localhost', 'PASSWORD': 'pulp', 'NAME': 'pulp', 'USER': 'postgres'}}}
+```
+
+## Comments:
+
+### comment by @rochacbruno on 2020-10-07 14:31:15 +0000 UTC
+
+The bug is in
+
+https://github.com/rochacbruno/dynaconf/blob/8998cac224a985dc8bb783f2a5abd71ff4e6769c/dynaconf/utils/__init__.py#L45
+
+As all the values are `pulp` it is wrongly using `is` to compare and `"pulp" is "pulp"` will always be `True` regardless the key it is in.
+
+```py
+>>> s1 = "pulp"
+>>> s2 = "pulp"
+>>> s1 is s2
+True
+```
+
+I will need to include the full path to the key on the comparison or change the `DynaBox` in a way that each value gets its own identity even if the value is the same.

--- a/example/issues/443_object_merge/app.py
+++ b/example/issues/443_object_merge/app.py
@@ -1,0 +1,25 @@
+from dynaconf.utils import object_merge
+from dynaconf.utils.boxing import DynaBox
+
+existing_data = DynaBox(
+    {
+        "DATABASES": {
+            "default": {
+                "ENGINE": "django.db.backends.postgresql_psycopg2",
+                "HOST": "localhost",
+                "PASSWORD": "pulp",
+                "NAME": "pulp",
+                "USER": "pulp",
+            }
+        }
+    }
+)
+assert existing_data["DATABASES"]["default"]["USER"] == "pulp"
+
+new_data = DynaBox({"DATABASES": {"default": {"USER": "postgres"}}})
+split_keys = ["DATABASES", "default", "USER"]
+new = object_merge(old=existing_data, new=new_data, full_path=split_keys)
+
+assert new["DATABASES"]["default"]["USER"] == "postgres"
+assert new["DATABASES"]["default"]["NAME"] == "pulp"
+assert new["DATABASES"]["default"]["PASSWORD"] == "pulp"


### PR DESCRIPTION
This solution is a temporary solution as it solves current
problem, but there is still the case for `None` values.

The best solution for this case would be wrapping all the values
on assignment and give it a full path signature to compare.

Fix #443 