### PR TITLE
Specify flask extension initializers by entry point object reference

### DIFF
--- a/docs/flask.md
+++ b/docs/flask.md
@@ -46,9 +46,9 @@ IF you don't want to manually create your config files take a look at the [CLI](
 
 You can tell Dynaconf to load your Flask Extensions dynamically as long as the extensions follows the Pattens of Flask extensions.
 
-The only requirement is that the extension must be a `callable` that accepts `app` as first argument. e.g: `flask_admin:Admin` or `custom_extension.module:init_app` and of course the extension must be in Python namespace to be imported.
+The only requirement is that the extension must be a `callable` that accepts `app` as first argument. e.g: `flask_admin:Admin` or `custom_extension.module:instance.init_app` and of course the extension must be in Python namespace to be imported.
 
-For extensions initialized just use the class or function path like: "flask_admin:Admin" or "extension.module:init_app"
+For extensions initialized just use an [entry point](https://packaging.python.org/specifications/entry-points/) object reference like: "flask_admin:Admin" or "extension.module:instance.init_app"
 
 having a `settings.toml`
 

--- a/example/dummy_flask_extension/README.md
+++ b/example/dummy_flask_extension/README.md
@@ -1,1 +1,1 @@
-This is an extension used only for testing of dynamic loading.
+These are extensions used only for testing of dynamic loading.

--- a/example/dummy_flask_extension/__init__.py
+++ b/example/dummy_flask_extension/__init__.py
@@ -1,0 +1,14 @@
+class DummyExtensionType(object):
+
+    def __init__(self, app=None):
+        self.app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        if not hasattr(app, 'extensions'):
+            app.extensions = {}
+        app.extensions['dummy'] = self
+
+
+dummy_instance = DummyExtensionType()

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -16,6 +16,19 @@ def test_dynamic_load_exts(settings):
     assert app.is_dummy_loaded is True
 
 
+def test_dynamic_load_entry_point(settings):
+    """Assert that a config based extensions support entry point syntax"""
+    app = Flask(__name__)
+    app.config["EXTENSIONS"] = [
+        "example.dummy_flask_extension:dummy_instance.init_app"]
+    FlaskDynaconf(app, dynaconf_instance=settings)
+    app.config.load_extensions()
+    assert app.config.EXTENSIONS == [
+        "example.dummy_flask_extension:dummy_instance.init_app"
+    ]
+    assert app.extensions['dummy'].__class__.__name__ == 'DummyExtensionType'
+
+
 def test_dynamic_load_exts_list(settings):
     """Assert that a config based extensions are loaded"""
     app = Flask(__name__)


### PR DESCRIPTION
### Description

An idiomatic pattern for many Flask extensions is to instantiate the extension at "import time", and call `[instance].init_app()` dynamically at run time.  E.g.:
```
# my_app.py
from flask import Flask
from flask_sqlalchemy import SQLAlchemy

db = SQLAlchemy()

def application_factory(*args, **kwargs):
    app = flask.Flask(*args, **kwargs)
    db.init_app(app)
    return app
```

This pattern is incompatible with the current implementation of `FlaskDynaconf.load_extensions`.  The current implementation allows for an import path specifying a module, and a single attribute of that module specifying the initialization callable.  E.g. `“flask_admin:Admin”` or `“extension.module:init_app”`.  However, there does not appear to be a way to specify calling a method of a "global" instance as above.

Fortunately, Python's [entry point](https://packaging.python.org/specifications/entry-points/) specification provides for this additional functionality in a backwards-compatible way with the current implementation.  The entry-point specification allows for the "attribute" (i.e., what comes after the `:`) to be nested arbitrarily deep in the importable object.  E.g., for the use case above, one could do something like the following:
```
# settings.toml
[default]
EXTENSIONS = [
    'my_app:db.init_app`,
]
```
```
# my_app.py
from flask import Flask
from flask_sqlalchemy import SQLAlchemy
from dynaconf import FlaskDynaconf

db = SQLAlchemy()

def application_factory(*args, **kwargs):
    app = flask.Flask(*args, **kwargs)
    FlaskDynaconf(app)
    app.config.load_extensions()
    return app
```

### Implementation

This pull request uses the entry point parsing and loading utilities provided by the `setuptools` package (specifically, `pkg_resources.EntryPoint.parse` and `pkg_resources.EntryPoint.resolve`).  These methods are fully backwards compatible with the existing `FlaskDynaconf.load_extensions` implementation.

An additional test has been added to verify the additional `EXTENSIONS` syntax made available by this change.