### PR TITLE
Fix: Environment variables filtering #470

### DIFF
--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -50,9 +50,9 @@ assert settings.STRING_NUM == "76"
 ```
 
 !!! tip
-    Dynaconf has multiple valid ways to access settings keys so it is compatible with your 
-    existing settings solution. You can access using `.notation`, `[item] indexing`, `.get method` 
-    and also it allows `.notation.nested` for data structures like dicts.  
+    Dynaconf has multiple valid ways to access settings keys so it is compatible with your
+    existing settings solution. You can access using `.notation`, `[item] indexing`, `.get method`
+    and also it allows `.notation.nested` for data structures like dicts.
     **Also variable access is case insensitive for the first level key**
 
 ## Custom Prefix
@@ -80,6 +80,14 @@ assert settings.PASSWD == 1234
 assert settings.db.name == "foo"
 assert settings.db.port == 2000
 assert settings.db.scheme == 'main'
+```
+
+If you don't want to use any prefix (load unprefixed variables) the correct
+way is to set it like so:
+```py
+from dynaconf import Dynaconf
+
+settings = Dynaconf(envvar_prefix=False)
 ```
 
 ## Dot env
@@ -125,3 +133,21 @@ export PREFIX_PATH='@format {env{"HOME"}/.config/{this.DB_NAME}'
 export PREFIX_PATH='@jinja {{env.HOME}}/.config/{{this.DB_NAME}} | abspath'
 ```
 
+## Environment variables filtering
+
+All environment variables (naturally, accounting for prefix rules) will be
+used and pulled into the settings space.
+
+You can change that behaviour by enabling the filtering of unknown environment
+variables:
+
+```py
+from dynaconf import Dynaconf
+
+settings = Dynaconf(ignore_unknown_envvars=True)
+```
+
+In that case, only previously defined variables (e.g. specified in
+`settings_file`/`settings_files`, `preload` or `includes`) will be loaded
+from the environment. This way your setting space can avoid pollution
+or potentially loading of sensitive information.

--- a/dynaconf/default_settings.py
+++ b/dynaconf/default_settings.py
@@ -113,6 +113,15 @@ DEFAULT_ENV_FOR_DYNACONF = get("DEFAULT_ENV_FOR_DYNACONF", "DEFAULT")
 # This namespace is used for files and also envvars
 ENVVAR_PREFIX_FOR_DYNACONF = get("ENVVAR_PREFIX_FOR_DYNACONF", "DYNACONF")
 
+# By default all environment variables (filtered by `envvar_prefix`) will
+# be pulled into settings space. In case some of them are polluting the space,
+# setting this flag to `True` will change this behaviour.
+# Only "known" variables will be considered -- that is variables defined before
+# in settings files (or includes/preloads).
+IGNORE_UNKNOWN_ENVVARS_FOR_DYNACONF = get(
+    "IGNORE_UNKNOWN_ENVVARS_FOR_DYNACONF", False
+)
+
 # The default encoding to open settings files
 ENCODING_FOR_DYNACONF = get("ENCODING_FOR_DYNACONF", "utf-8")
 

--- a/example/ignore_unknown_envvars/.env
+++ b/example/ignore_unknown_envvars/.env
@@ -1,0 +1,11 @@
+# Unwanted, unprefixed variable.
+SECRET=hunter1
+
+# Unwanted, prefixed variable.
+MYAPP_SECRET=hunter1
+
+# Wanted, unprefixed variable.
+VAR1=bar
+
+# Wanted, prefixed variable.
+MYAPP_VAR1=ham

--- a/example/ignore_unknown_envvars/app.py
+++ b/example/ignore_unknown_envvars/app.py
@@ -1,0 +1,25 @@
+from dynaconf import LazySettings
+
+
+# No prefix.
+settings = LazySettings(
+    settings_file="settings.toml",
+    load_dotenv=True,
+    ignore_unknown_envvars=True,
+    envvar_prefix=False,
+)
+
+assert settings.VAR1 == "bar"
+assert not settings.get("SECRET")
+
+
+# MYAPP_ prefix.
+settings = LazySettings(
+    settings_file="settings.toml",
+    load_dotenv=True,
+    ignore_unknown_envvars=True,
+    envvar_prefix="MYAPP",
+)
+
+assert settings.VAR1 == "ham"
+assert not settings.get("SECRET")

--- a/example/ignore_unknown_envvars/settings.toml
+++ b/example/ignore_unknown_envvars/settings.toml
@@ -1,0 +1,3 @@
+# Here pre-defining known variables.
+var1 = "foo"
+var2 = "qux"


### PR DESCRIPTION
Fixes #470 

Added new global option `ignore_unknown_envvars` / `IGNORE_UNKNOWN_ENVVARS_FOR_DYNACONF`.
Included is example app and some docs changes describing the usage.