### PR TITLE
Case insensitive envvar traversal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ test_examples:
 	cd example/issues/430_same_name;pwd;python app.py
 	cd example/issues/443_object_merge;pwd;python app.py
 	cd example/issues/445_casting;pwd;python app.py
+	cd example/issues/519_underscore_in_name;pwd;ATC_BLE__device_id=42 EXPECTED_VALUE=42 python app.py
+	cd example/issues/519_underscore_in_name;pwd;ATC_BLE__DEVICE_ID=42 EXPECTED_VALUE=42 python app.py
 
 test_vault:
 	# @cd example/vault;pwd;python write.py

--- a/docs/django.md
+++ b/docs/django.md
@@ -86,6 +86,9 @@ DATABASES = {
 }
 ```
 
+!!! warning
+    Notice that casing is important for Django settings, so `DYNACONF_DATABASES__default__ENGINE` is not the same as `DYNACONF_DATABASES__DEFAULT__ENGINE` you must use the first which matched the proper django settings.
+
 Read more on [environment variables](https://dynaconf.readthedocs.io/en/latest/guides/environment_variables.html#nested-keys-in-dictionaries-via-environment-variables)
 
 ## Settings files

--- a/docs/index.md
+++ b/docs/index.md
@@ -459,6 +459,9 @@ It is also possible to make dynaconf to read the files separated by layered
 environments so each section or first level key is loaded as a
 distinct environment.
 
+!!! warning
+    To enable layered environments the argument `environments` must be set to `True`, otherwise dynaconf will ignore layers and read all first level keys as normal values.
+
 === "config.py"
     ```py
     settings = Dynaconf(environments=True)

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -44,7 +44,7 @@ def object_merge(old, new, unique=False, full_path=None):
 
             if (
                 existing_value is not None
-                and key == full_path[-1]
+                and key.lower() == full_path[-1].lower()
                 and existing_value is value
             ):
                 # Here Be The Dragons

--- a/example/issues/519_underscore_in_name/app.py
+++ b/example/issues/519_underscore_in_name/app.py
@@ -1,0 +1,13 @@
+import os
+
+from dynaconf import Dynaconf
+
+config = Dynaconf(settings_files=["settings.yml"], envvar_prefix="ATC",)
+
+# envvar set is case insensitive
+# ATC_BLE__DEVICE_ID=x and ATC_BLE__device_id=x are the same
+expected = os.environ.get("EXPECTED_VALUE", 0)
+
+# access is case insensitive
+assert config.ble.device_id == int(expected)
+assert config.BLE.DEVICE_ID == int(expected)

--- a/example/issues/519_underscore_in_name/settings.yml
+++ b/example/issues/519_underscore_in_name/settings.yml
@@ -1,0 +1,2 @@
+ble:
+  device_id: 0


### PR DESCRIPTION
Fix #519
Fix #516

Now `export DYNACONF_FOO__bar__zaz` is the same as
`DYNACONF_FOO__BAR__ZAZ`

> first level prefix still needs to be uppercase!

Added a warning about django to the docs.