### PR TITLE
Fix #478 Make alias for environment -> environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ test_examples:
 	cd example/issues/430_same_name;pwd;python app.py
 	cd example/issues/443_object_merge;pwd;python app.py
 	cd example/issues/445_casting;pwd;python app.py
+	cd example/issues/478_mispell_environments;pwd;python app.py
 	cd example/issues/482_layered_format;pwd;python app.py
 	cd example/issues/486_title_case_validation;pwd;python app.py
 	cd example/issues/494_using_pathlib;pwd;python app.py

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -115,6 +115,8 @@ class LazySettings(LazyObject):
         mispells = {
             "settings_files": "settings_file",
             "SETTINGS_FILES": "SETTINGS_FILE",
+            "environment": "environments",
+            "ENVIRONMENT": "ENVIRONMENTS",
         }
         for mispell, correct in mispells.items():
             if mispell in kwargs:

--- a/example/issues/478_mispell_environments/app.py
+++ b/example/issues/478_mispell_environments/app.py
@@ -1,0 +1,19 @@
+from dynaconf import Dynaconf
+
+
+settings = Dynaconf(
+    environment=True,  # should be environents but it is an alias
+    settings_files="settings.toml",  # should be settings_file it is an alias
+)
+
+
+assert settings.NAME == "Bruno"
+
+
+settings = Dynaconf(
+    ENVIRONMENT=True,  # should be environents but it is an alias
+    SETTINGS_FILES="settings.toml",  # should be settings_file it is an alias
+)
+
+
+assert settings.NAME == "Bruno"

--- a/example/issues/478_mispell_environments/settings.toml
+++ b/example/issues/478_mispell_environments/settings.toml
@@ -1,0 +1,5 @@
+[default]
+name = "default name"
+
+[development]
+name = "Bruno"


### PR DESCRIPTION
This is a commom mistake to pass `environment` so it is alias.

Fix #478