### PR TITLE
HOTFIX for 462 related issue, `default` on .get should be parsed as Box objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ test_examples:
 
 	@echo '###############  Django Admin From root folder  ###############'
 	PYTHONPATH=./example/django_example/ DJANGO_SETTINGS_MODULE=foo.settings django-admin test polls -v 2
+	PYTHONPATH=./example/issues/449_django_lazy_path/ DJANGO_SETTINGS_MODULE=foo.settings django-admin test polls -v 2
 	PYTHONPATH=./example/django_example_compat/ DJANGO_SETTINGS_MODULE=foo.settings django-admin test polls -v 2
 
 	@echo '############ Issues  ##################'

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -31,6 +31,7 @@ from dynaconf.utils.parse_conf import get_converter
 from dynaconf.utils.parse_conf import parse_conf_data
 from dynaconf.utils.parse_conf import true_values
 from dynaconf.validator import ValidatorList
+from dynaconf.vendor.box.box_list import BoxList
 
 
 class LazySettings(LazyObject):
@@ -432,6 +433,13 @@ class Settings:
                 fresh=fresh,
                 parent=parent,
             )
+
+        if default is not None:
+            # default values should behave exactly Dynaconf parsed values
+            if isinstance(default, list):
+                default = BoxList(default)
+            elif isinstance(default, dict):
+                default = DynaBox(default)
 
         key = upperfy(key)
         if key in self._deleted:

--- a/example/issues/449_django_lazy_path/foo/settings.py
+++ b/example/issues/449_django_lazy_path/foo/settings.py
@@ -34,7 +34,6 @@ settings = dynaconf.DjangoDynaconf(
 )  # noqa
 # HERE ENDS DYNACONF EXTENSION LOAD (No more code below this line)
 
-
 # test
 assert settings.SERVER == "prodserver.com"
 # assert settings.STATIC_URL == "/changed/in/settings.toml/by/dynaconf/"
@@ -46,3 +45,21 @@ assert settings.FOO == "It overrides every other env"
 assert settings.TEMPLATES[0]["DIRS"] == [
     f"{BASE_DIR}/templates"
 ], settings.TEMPLATES[0]["DIRS"]
+
+ALLOWED_HOSTS = settings.get(
+    "ALLOWED_HOSTS", ["::1", "127.0.0.1", "localhost"]
+)
+DUMMY_LIST = settings.get(
+    "DUMMY_LIST",
+    [
+        "a",
+        "dummy",
+        "list",
+    ],  # will be converted to a BoxList to keep the same API
+)
+
+# this is going to be a BoxList from yaml file
+ALLOWED_HOSTS.to_list()
+
+# this is going to be a list provided as default, but still with the same api.
+DUMMY_LIST.to_list()


### PR DESCRIPTION

In order to keep the same method api, default values should be parsed
and converted to Boxed objects.

https://github.com/rochacbruno/dynaconf/issues/462