### PR TITLE
WIP - feat: adding settings file prefix option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -407,6 +407,17 @@ Read more on [settings_files](/settings_files/)
 
 ---
 
+### **settings_file_prefix**
+
+The prefix for dynaconf to load values from settings files (ini, json, toml and yaml). If this is not set it will
+import everything found in the settings file as is.
+
+
+- type: str
+- default: None
+
+---
+
 ### **skip_files**
 
 When using a glob on `includes` you might want dynaconf to ignore some files that matches.

--- a/dynaconf/loaders/ini_loader.py
+++ b/dynaconf/loaders/ini_loader.py
@@ -26,6 +26,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     if ConfigObj is None:  # pragma: no cover
         BaseLoader.warn_not_installed(obj, "ini")
         return
+    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
 
     loader = BaseLoader(
         obj=obj,
@@ -35,7 +36,12 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         file_reader=lambda fileobj: ConfigObj(fileobj).dict(),
         string_reader=lambda strobj: ConfigObj(strobj.split("\n")).dict(),
     )
-    loader.load(filename=filename, key=key, silent=silent)
+    loader.load(
+        filename=filename,
+        key=key,
+        silent=silent,
+        prefix=settings_file_prefix,
+    )
 
 
 def write(settings_path, settings_data, merge=True):

--- a/dynaconf/loaders/json_loader.py
+++ b/dynaconf/loaders/json_loader.py
@@ -33,6 +33,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     else:
         file_reader = json.load
         string_reader = json.loads
+    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
 
     loader = BaseLoader(
         obj=obj,
@@ -42,7 +43,12 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         file_reader=file_reader,
         string_reader=string_reader,
     )
-    loader.load(filename=filename, key=key, silent=silent)
+    loader.load(
+        filename=filename,
+        key=key,
+        silent=silent,
+        prefix=settings_file_prefix,
+    )
 
 
 def write(settings_path, settings_data, merge=True):

--- a/dynaconf/loaders/toml_loader.py
+++ b/dynaconf/loaders/toml_loader.py
@@ -19,6 +19,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     :param filename: Optional custom filename to load
     :return: None
     """
+    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
 
     loader = BaseLoader(
         obj=obj,
@@ -28,7 +29,12 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         file_reader=toml.load,
         string_reader=toml.loads,
     )
-    loader.load(filename=filename, key=key, silent=silent)
+    loader.load(
+        filename=filename,
+        key=key,
+        silent=silent,
+        prefix=settings_file_prefix,
+    )
 
 
 def write(settings_path, settings_data, merge=True):

--- a/dynaconf/loaders/yaml_loader.py
+++ b/dynaconf/loaders/yaml_loader.py
@@ -40,6 +40,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
             " Please read https://msg.pyyaml.org/load for full details."
             " Try to use full_load or safe_load."
         )
+    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
 
     loader = BaseLoader(
         obj=obj,
@@ -49,7 +50,12 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         file_reader=yaml_reader,
         string_reader=yaml_reader,
     )
-    loader.load(filename=filename, key=key, silent=silent)
+    loader.load(
+        filename=filename,
+        key=key,
+        silent=silent,
+        prefix=settings_file_prefix,
+    )
 
 
 def write(settings_path, settings_data, merge=True):

--- a/example/toml_example/app.py
+++ b/example/toml_example/app.py
@@ -1,4 +1,4 @@
-from dynaconf import settings
+from dynaconf import settings, LazySettings
 
 # print all values in the file
 # using [default] + [development] + [global] values
@@ -51,6 +51,7 @@ assertions = {
     "ENABLED": True,
     "WORKS": "toml_example in dev env",
     "CUSTOM": "this is custom from [development]",
+    "PREFIX_CUSTOM": "this is custom when we set a prefix",
     "TEST_LOADERS": {"dev": "test_dev", "prod": "test_prod"},
 }
 
@@ -79,3 +80,8 @@ for key, value in assertions.items():
     found = settings.from_env("production").get(key)
     assert found == getattr(settings.from_env("production"), key)
     assert found == value, f"expected: {key}: [{value}] found: [{found}]"
+
+
+settings = LazySettings(settings_file="settings.toml", settings_file_prefix="prefix")
+settings.from_env("default")
+assert settings.custom == "this is custom when we set a prefix"

--- a/example/toml_example/app.py
+++ b/example/toml_example/app.py
@@ -82,6 +82,9 @@ for key, value in assertions.items():
     assert found == value, f"expected: {key}: [{value}] found: [{found}]"
 
 
-settings = LazySettings(settings_file="settings.toml", settings_file_prefix="prefix")
+settings = LazySettings(
+    settings_file="settings.toml",
+    settings_file_prefix="prefix",
+)
 settings.from_env("default")
 assert settings.custom == "this is custom when we set a prefix"

--- a/example/toml_example/settings.toml
+++ b/example/toml_example/settings.toml
@@ -13,6 +13,7 @@ age = 42.0
 enabled = true
 works = "toml_example"
 custom = 'this is custom from [default]'
+prefix_custom = "this is custom when we set a prefix"
 
   [default.test_loaders]
   dev = "test_dev"

--- a/example/yaml_example/yaml_as_extra_config/app.py
+++ b/example/yaml_example/yaml_as_extra_config/app.py
@@ -1,4 +1,4 @@
-from dynaconf import settings
+from dynaconf import settings, LazySettings
 
 print(settings.YAML)
 print(settings.HOST)
@@ -34,6 +34,7 @@ assertions = {
     "HOST": "prod_server.com",
     "PORT": 5000,
     "ENVIRONMENT": "this is production",
+    "PREFIX_CUSTOM": "this is custom when prefix is set",
 }
 
 
@@ -41,3 +42,6 @@ for key, value in assertions.items():
     found = settings.from_env("production").get(key)
     assert found == getattr(settings.from_env("production"), key)
     assert found == value, f"expected: {key}: [{value}] found: [{found}]"
+
+settings = LazySettings(settings_file_prefix="prefix")
+assert settings.CUSTOM == "this is custom when prefix is set"

--- a/example/yaml_example/yaml_as_extra_config/settings.py
+++ b/example/yaml_example/yaml_as_extra_config/settings.py
@@ -1,3 +1,4 @@
 HOST = "default.com"
 PORT = 9000
+PREFIX_CUSTOM = "this is custom when prefix is set"
 YAML = "extra_settings.yaml"  # DEPRECATED

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -842,6 +842,26 @@ def test_envless_mode(tmpdir):
     assert settings.DATABASES.default.port == 8080
 
 
+def test_envless_mode_with_prefix(tmpdir):
+    data = {
+        "prefix_foo": "bar",
+        "hello": "world",
+        "prefix_default": 1,
+        "prefix_databases": {"default": {"port": 8080}},
+    }
+    toml_loader.write(str(tmpdir.join("settings.toml")), data)
+
+    settings = LazySettings(
+        settings_file="settings.toml",
+        SETTINGS_FILE_PREFIX="prefix",
+    )  # already the default
+    assert settings.FOO == "bar"
+    with pytest.raises(AttributeError):
+        settings.HELLO
+    assert settings.DEFAULT == 1
+    assert settings.DATABASES.default.port == 8080
+
+
 def test_lowercase_read_mode(tmpdir):
     """
     Starting on 3.0.0 lowercase keys are enabled by default

--- a/tests/test_ini_loader.py
+++ b/tests/test_ini_loader.py
@@ -189,3 +189,17 @@ def test_envless():
     assert settings.a == "a,b"
     assert settings.COLORS.white.code == "#FFFFFF"
     assert settings.COLORS.white.name == "white"
+
+
+def test_prefix():
+    settings = LazySettings(settings_file_prefix="prefix")
+    ini = """
+    prefix_a = "a,b"
+    prefix_colors__white__code = '#FFFFFF'
+    COLORS__white__name = 'white'
+    """
+    load(settings, filename=ini)
+    assert settings.a == "a,b"
+    assert settings.COLORS.white.code == "#FFFFFF"
+    with pytest.raises(AttributeError):
+        settings.COLORS.white.name

--- a/tests/test_json_loader.py
+++ b/tests/test_json_loader.py
@@ -212,3 +212,17 @@ def test_envless():
     load(settings, filename=_json)
     assert settings.COLORS.yellow.code == "#FFCC00"
     assert settings.COLORS.yellow.name == "Yellow"
+
+
+def test_prefix():
+    settings = LazySettings(settings_file_prefix="prefix")
+    _json = """
+    {
+        "prefix_colors__yellow__code": "#FFCC00",
+        "COLORS__yellow__name": "Yellow"
+    }
+    """
+    load(settings, filename=_json)
+    assert settings.COLORS.yellow.code == "#FFCC00"
+    with pytest.raises(AttributeError):
+        settings.COLORS.yellow.name

--- a/tests/test_toml_loader.py
+++ b/tests/test_toml_loader.py
@@ -206,3 +206,17 @@ def test_envless():
     assert settings.a == "a,b"
     assert settings.COLORS.white.code == "#FFFFFF"
     assert settings.COLORS.white.name == "white"
+
+
+def test_prefix():
+    settings = LazySettings(settings_file_prefix="prefix")
+    ini = """
+    prefix_a = "a,b"
+    prefix_colors__white__code = '#FFFFFF'
+    COLORS__white__name = 'white'
+    """
+    load(settings, filename=ini)
+    assert settings.a == "a,b"
+    assert settings.COLORS.white.code == "#FFFFFF"
+    with pytest.raises(AttributeError):
+        settings.COLORS.white.name

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -297,6 +297,20 @@ def test_envless():
     assert settings.COLORS.white.name == "white"
 
 
+def test_prefix():
+    settings = LazySettings(settings_file_prefix="prefix")
+    _yaml = """
+    prefix_a: a,b
+    prefix_colors__white__code: "#FFFFFF"
+    COLORS__white__name: "white"
+    """
+    load(settings, filename=_yaml)
+    assert settings.a == "a,b"
+    assert settings.COLORS.white.code == "#FFFFFF"
+    with pytest.raises(AttributeError):
+        settings.COLORS.white.name
+
+
 def test_empty_env():
     settings = LazySettings(environments=True)
     _yaml = """


### PR DESCRIPTION
Related to: https://github.com/rochacbruno/dynaconf/issues/621

This adds a `settings_file_prefix` option for toml, json, ini and yaml files which works similarly to `envvar_prefix`, however it defaults to `None` and does not filter out any keys if it is not set.