### PR TITLE
feat: add filter strategy with PrefixFilter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -407,6 +407,17 @@ Read more on [settings_files](/settings_files/)
 
 ---
 
+### **settings_file_prefix**
+
+The prefix for dynaconf to load values from settings files (ini, json, toml and yaml). If this is not set it will
+import everything found in the settings file as is.
+
+
+- type: str
+- default: None
+
+---
+
 ### **skip_files**
 
 When using a glob on `includes` you might want dynaconf to ignore some files that matches.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -407,13 +407,12 @@ Read more on [settings_files](/settings_files/)
 
 ---
 
-### **settings_file_prefix**
+### **filtering_strategy**
 
-The prefix for dynaconf to load values from settings files (ini, json, toml and yaml). If this is not set it will
-import everything found in the settings file as is.
+Callable accepting data to be filtered, inbuilts currently include [PrefixFilter](/dynaconf/strategies/filtering.py)
 
 
-- type: str
+- type: class
 - default: None
 
 ---

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -35,7 +35,7 @@ from dynaconf.vendor.box.box_list import BoxList
 
 
 class LazySettings(LazyObject):
-    """Loads settings lazily from multple sources::
+    """Loads settings lazily from multiple sources::
 
         settings = Dynaconf(
             settings_files=["settings.toml"],  # path/glob
@@ -203,6 +203,7 @@ class Settings:
         self._not_installed_warnings = []
         self._validate_only = kwargs.pop("validate_only", None)
         self._validate_exclude = kwargs.pop("validate_exclude", None)
+        self._settings_file_prefix = kwargs.get("settings_file_prefix", None)
 
         self.validators = ValidatorList(
             self, validators=kwargs.pop("validators", None)
@@ -537,6 +538,10 @@ class Settings:
             for key in UPPER_DEFAULT_SETTINGS
             if key not in RENAMED_VARS
         }
+
+        if self._settings_file_prefix:
+            # We need to retain the prefix when switching environments
+            new_data["settings_file_prefix"] = self._settings_file_prefix
 
         # This is here for backwards compatibility
         # To be removed on 4.x.x
@@ -1180,5 +1185,6 @@ RESERVED_ATTRS = (
         "validators",
         "_validate_only",
         "_validate_exclude",
+        "_settings_file_prefix",
     ]
 )

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -200,10 +200,10 @@ class Settings:
         self._defaults = DynaBox(box_settings=self)
         self.environ = os.environ
         self.SETTINGS_MODULE = None
+        self.settings_file_prefix = kwargs.get("settings_file_prefix", None)
         self._not_installed_warnings = []
         self._validate_only = kwargs.pop("validate_only", None)
         self._validate_exclude = kwargs.pop("validate_exclude", None)
-        self._settings_file_prefix = kwargs.get("settings_file_prefix", None)
 
         self.validators = ValidatorList(
             self, validators=kwargs.pop("validators", None)
@@ -539,9 +539,9 @@ class Settings:
             if key not in RENAMED_VARS
         }
 
-        if self._settings_file_prefix:
+        if self.settings_file_prefix:
             # We need to retain the prefix when switching environments
-            new_data["settings_file_prefix"] = self._settings_file_prefix
+            new_data["settings_file_prefix"] = self.settings_file_prefix
 
         # This is here for backwards compatibility
         # To be removed on 4.x.x
@@ -1182,9 +1182,9 @@ RESERVED_ATTRS = (
         "_warn_dynaconf_global_settings",
         "environ",
         "SETTINGS_MODULE",
+        "settings_file_prefix",
         "validators",
         "_validate_only",
         "_validate_exclude",
-        "_settings_file_prefix",
     ]
 )

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -200,7 +200,7 @@ class Settings:
         self._defaults = DynaBox(box_settings=self)
         self.environ = os.environ
         self.SETTINGS_MODULE = None
-        self.settings_file_prefix = kwargs.get("settings_file_prefix", None)
+        self.filter_strategy = kwargs.get("filter_strategy", None)
         self._not_installed_warnings = []
         self._validate_only = kwargs.pop("validate_only", None)
         self._validate_exclude = kwargs.pop("validate_exclude", None)
@@ -539,9 +539,9 @@ class Settings:
             if key not in RENAMED_VARS
         }
 
-        if self.settings_file_prefix:
-            # We need to retain the prefix when switching environments
-            new_data["settings_file_prefix"] = self.settings_file_prefix
+        if self.filter_strategy:
+            # Retain the filtering strategy when switching environments
+            new_data["filter_strategy"] = self.filter_strategy
 
         # This is here for backwards compatibility
         # To be removed on 4.x.x
@@ -1182,7 +1182,7 @@ RESERVED_ATTRS = (
         "_warn_dynaconf_global_settings",
         "environ",
         "SETTINGS_MODULE",
-        "settings_file_prefix",
+        "filter_strategy",
         "validators",
         "_validate_only",
         "_validate_exclude",

--- a/dynaconf/loaders/base.py
+++ b/dynaconf/loaders/base.py
@@ -127,7 +127,7 @@ class BaseLoader:
 
             for env in build_env_list(self.obj, self.env):
                 env = env.lower()  # lower for better comparison
-                data = {}
+
                 try:
                     data = file_data[env] or {}
                 except KeyError:

--- a/dynaconf/loaders/base.py
+++ b/dynaconf/loaders/base.py
@@ -127,6 +127,7 @@ class BaseLoader:
 
             for env in build_env_list(self.obj, self.env):
                 env = env.lower()  # lower for better comparison
+                data = {}
                 try:
                     data = file_data[env] or {}
                 except KeyError:

--- a/dynaconf/loaders/base.py
+++ b/dynaconf/loaders/base.py
@@ -107,17 +107,11 @@ class BaseLoader:
     def _envless_load(self, source_data, silent=True, key=None, prefix=None):
         """Load all the keys from each file without env separation"""
         for file_data in source_data.values():
-            if prefix:
-                file_data = {
-                    upperfy(
-                        k[len(prefix):]
-                    ): v for k, v in file_data.items()
-                    if upperfy(k[:len(prefix)]) == prefix
-                }
             self._set_data_to_obj(
                 file_data,
                 self.identifier,
                 key=key,
+                prefix=prefix,
             )
 
     def _load_all_envs(self, source_data, silent=True, key=None, prefix=None):
@@ -135,13 +129,6 @@ class BaseLoader:
                 env = env.lower()  # lower for better comparison
                 try:
                     data = file_data[env] or {}
-                    if prefix:
-                        data = {
-                            upperfy(
-                                k[len(prefix):]
-                            ): v for k, v in data.items()
-                            if upperfy(k[:len(prefix)]) == prefix
-                        }
                 except KeyError:
                     if silent:
                         continue
@@ -159,6 +146,7 @@ class BaseLoader:
                     identifier,
                     file_merge,
                     key,
+                    prefix=prefix,
                 )
 
     def _set_data_to_obj(
@@ -167,6 +155,7 @@ class BaseLoader:
         identifier,
         file_merge=None,
         key=False,
+        prefix=None,
     ):
         """Calls setttings.set to add the keys"""
         # data 1st level keys should be transformed to upper case.
@@ -174,9 +163,16 @@ class BaseLoader:
         if key:
             key = upperfy(key)
 
+        if prefix:
+            data = {
+                upperfy(
+                    k[len(prefix):]
+                ): v for k, v in data.items()
+                if upperfy(k[:len(prefix)]) == prefix
+            }
+
         # is there a `dynaconf_merge` inside an `[env]`?
         file_merge = file_merge or data.pop("DYNACONF_MERGE", False)
-
         if not key:
             self.obj.update(
                 data,

--- a/dynaconf/loaders/ini_loader.py
+++ b/dynaconf/loaders/ini_loader.py
@@ -26,7 +26,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     if ConfigObj is None:  # pragma: no cover
         BaseLoader.warn_not_installed(obj, "ini")
         return
-    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
+    settings_file_prefix = obj.settings_file_prefix
 
     loader = BaseLoader(
         obj=obj,

--- a/dynaconf/loaders/ini_loader.py
+++ b/dynaconf/loaders/ini_loader.py
@@ -26,7 +26,6 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     if ConfigObj is None:  # pragma: no cover
         BaseLoader.warn_not_installed(obj, "ini")
         return
-    settings_file_prefix = obj.settings_file_prefix
 
     loader = BaseLoader(
         obj=obj,
@@ -40,7 +39,6 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         filename=filename,
         key=key,
         silent=silent,
-        prefix=settings_file_prefix,
     )
 
 

--- a/dynaconf/loaders/ini_loader.py
+++ b/dynaconf/loaders/ini_loader.py
@@ -26,6 +26,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     if ConfigObj is None:  # pragma: no cover
         BaseLoader.warn_not_installed(obj, "ini")
         return
+    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
 
     loader = BaseLoader(
         obj=obj,
@@ -35,7 +36,12 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         file_reader=lambda fileobj: ConfigObj(fileobj).dict(),
         string_reader=lambda strobj: ConfigObj(strobj.split("\n")).dict(),
     )
-    loader.load(filename=filename, key=key, silent=silent)
+    loader.load(
+        filename=filename,
+        key=key,
+        silent=silent,
+        prefix=settings_file_prefix,
+    )
 
 
 def write(settings_path, settings_data, merge=True):

--- a/dynaconf/loaders/json_loader.py
+++ b/dynaconf/loaders/json_loader.py
@@ -33,6 +33,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     else:
         file_reader = json.load
         string_reader = json.loads
+    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
 
     loader = BaseLoader(
         obj=obj,
@@ -42,7 +43,12 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         file_reader=file_reader,
         string_reader=string_reader,
     )
-    loader.load(filename=filename, key=key, silent=silent)
+    loader.load(
+        filename=filename,
+        key=key,
+        silent=silent,
+        prefix=settings_file_prefix,
+    )
 
 
 def write(settings_path, settings_data, merge=True):

--- a/dynaconf/loaders/json_loader.py
+++ b/dynaconf/loaders/json_loader.py
@@ -33,7 +33,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     else:
         file_reader = json.load
         string_reader = json.loads
-    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
+    settings_file_prefix = obj.settings_file_prefix
 
     loader = BaseLoader(
         obj=obj,

--- a/dynaconf/loaders/json_loader.py
+++ b/dynaconf/loaders/json_loader.py
@@ -33,7 +33,6 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     else:
         file_reader = json.load
         string_reader = json.loads
-    settings_file_prefix = obj.settings_file_prefix
 
     loader = BaseLoader(
         obj=obj,
@@ -47,7 +46,6 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         filename=filename,
         key=key,
         silent=silent,
-        prefix=settings_file_prefix,
     )
 
 

--- a/dynaconf/loaders/toml_loader.py
+++ b/dynaconf/loaders/toml_loader.py
@@ -19,7 +19,6 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     :param filename: Optional custom filename to load
     :return: None
     """
-    settings_file_prefix = obj.settings_file_prefix
 
     loader = BaseLoader(
         obj=obj,
@@ -33,7 +32,6 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         filename=filename,
         key=key,
         silent=silent,
-        prefix=settings_file_prefix,
     )
 
 

--- a/dynaconf/loaders/toml_loader.py
+++ b/dynaconf/loaders/toml_loader.py
@@ -19,6 +19,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     :param filename: Optional custom filename to load
     :return: None
     """
+    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
 
     loader = BaseLoader(
         obj=obj,
@@ -28,7 +29,12 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         file_reader=toml.load,
         string_reader=toml.loads,
     )
-    loader.load(filename=filename, key=key, silent=silent)
+    loader.load(
+        filename=filename,
+        key=key,
+        silent=silent,
+        prefix=settings_file_prefix,
+    )
 
 
 def write(settings_path, settings_data, merge=True):

--- a/dynaconf/loaders/toml_loader.py
+++ b/dynaconf/loaders/toml_loader.py
@@ -19,7 +19,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     :param filename: Optional custom filename to load
     :return: None
     """
-    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
+    settings_file_prefix = obj.settings_file_prefix
 
     loader = BaseLoader(
         obj=obj,

--- a/dynaconf/loaders/yaml_loader.py
+++ b/dynaconf/loaders/yaml_loader.py
@@ -40,6 +40,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
             " Please read https://msg.pyyaml.org/load for full details."
             " Try to use full_load or safe_load."
         )
+    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
 
     loader = BaseLoader(
         obj=obj,
@@ -49,7 +50,12 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         file_reader=yaml_reader,
         string_reader=yaml_reader,
     )
-    loader.load(filename=filename, key=key, silent=silent)
+    loader.load(
+        filename=filename,
+        key=key,
+        silent=silent,
+        prefix=settings_file_prefix,
+    )
 
 
 def write(settings_path, settings_data, merge=True):

--- a/dynaconf/loaders/yaml_loader.py
+++ b/dynaconf/loaders/yaml_loader.py
@@ -40,7 +40,6 @@ def load(obj, env=None, silent=True, key=None, filename=None):
             " Please read https://msg.pyyaml.org/load for full details."
             " Try to use full_load or safe_load."
         )
-    settings_file_prefix = obj.settings_file_prefix
 
     loader = BaseLoader(
         obj=obj,
@@ -54,7 +53,6 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         filename=filename,
         key=key,
         silent=silent,
-        prefix=settings_file_prefix,
     )
 
 

--- a/dynaconf/loaders/yaml_loader.py
+++ b/dynaconf/loaders/yaml_loader.py
@@ -40,7 +40,7 @@ def load(obj, env=None, silent=True, key=None, filename=None):
             " Please read https://msg.pyyaml.org/load for full details."
             " Try to use full_load or safe_load."
         )
-    settings_file_prefix = obj.get("SETTINGS_FILE_PREFIX", None)
+    settings_file_prefix = obj.settings_file_prefix
 
     loader = BaseLoader(
         obj=obj,

--- a/dynaconf/strategies/filtering.py
+++ b/dynaconf/strategies/filtering.py
@@ -1,0 +1,19 @@
+from dynaconf.utils import upperfy
+
+
+class PrefixFilter:
+
+    def __init__(self, prefix):
+        if not isinstance(prefix, str):
+            raise TypeError("`SETTINGS_FILE_PREFIX` must be str")
+        self.prefix = "{}_".format(upperfy(prefix))
+
+    def __call__(self, data):
+        """Filter incoming data by prefix"""
+        prefix = self.prefix
+        return {
+                upperfy(
+                    k[len(prefix):]
+                ): v for k, v in data.items()
+                if upperfy(k[:len(prefix)]) == prefix
+         }

--- a/example/toml_example/app.py
+++ b/example/toml_example/app.py
@@ -1,4 +1,4 @@
-from dynaconf import settings
+from dynaconf import settings, LazySettings
 
 # print all values in the file
 # using [default] + [development] + [global] values
@@ -51,6 +51,7 @@ assertions = {
     "ENABLED": True,
     "WORKS": "toml_example in dev env",
     "CUSTOM": "this is custom from [development]",
+    "PREFIX_CUSTOM": "this is custom when we set a prefix",
     "TEST_LOADERS": {"dev": "test_dev", "prod": "test_prod"},
 }
 
@@ -79,3 +80,8 @@ for key, value in assertions.items():
     found = settings.from_env("production").get(key)
     assert found == getattr(settings.from_env("production"), key)
     assert found == value, f"expected: {key}: [{value}] found: [{found}]"
+
+
+settings = LazySettings(settings_file="settings.toml", settings_file_prefix="prefix")
+settings.from_env("default")
+assert settings.custom == "this is custom when we set a prefix"

--- a/example/toml_example/app.py
+++ b/example/toml_example/app.py
@@ -1,4 +1,5 @@
 from dynaconf import settings, Dynaconf
+from dynaconf.strategies.filtering import PrefixFilter
 
 # print all values in the file
 # using [default] + [development] + [global] values
@@ -84,7 +85,7 @@ for key, value in assertions.items():
 
 settings_with_prefix = Dynaconf(
     settings_files=["settings.toml"],
-    settings_file_prefix="prefix",
+    filter_strategy=PrefixFilter("prefix"),
     environments=True,
 )
 with settings_with_prefix.using_env("default"):

--- a/example/toml_example/app.py
+++ b/example/toml_example/app.py
@@ -1,4 +1,4 @@
-from dynaconf import settings, LazySettings
+from dynaconf import settings, Dynaconf
 
 # print all values in the file
 # using [default] + [development] + [global] values
@@ -82,9 +82,11 @@ for key, value in assertions.items():
     assert found == value, f"expected: {key}: [{value}] found: [{found}]"
 
 
-settings = LazySettings(
-    settings_file="settings.toml",
+settings_with_prefix = Dynaconf(
+    settings_files=["settings.toml"],
     settings_file_prefix="prefix",
+    environments=True,
 )
-settings.from_env("default")
-assert settings.custom == "this is custom when we set a prefix"
+with settings_with_prefix.using_env("default"):
+    assert settings_with_prefix.CUSTOM == "this is custom when we set a prefix"
+assert settings_with_prefix.from_env("production").CUSTOM == "this is custom when we set a prefix"

--- a/example/toml_example/app.py
+++ b/example/toml_example/app.py
@@ -89,4 +89,6 @@ settings_with_prefix = Dynaconf(
 )
 with settings_with_prefix.using_env("default"):
     assert settings_with_prefix.CUSTOM == "this is custom when we set a prefix"
-assert settings_with_prefix.from_env("production").CUSTOM == "this is custom when we set a prefix"
+assert settings_with_prefix.from_env(
+    "production"
+).CUSTOM == "this is custom when we set a prefix"

--- a/example/toml_example/app.py
+++ b/example/toml_example/app.py
@@ -82,6 +82,9 @@ for key, value in assertions.items():
     assert found == value, f"expected: {key}: [{value}] found: [{found}]"
 
 
-settings = LazySettings(settings_file="settings.toml", settings_file_prefix="prefix")
+settings = LazySettings(
+    settings_file="settings.toml",
+    settings_file_prefix="prefix",
+)
 settings.from_env("default")
 assert settings.custom == "this is custom when we set a prefix"

--- a/example/toml_example/settings.toml
+++ b/example/toml_example/settings.toml
@@ -13,6 +13,7 @@ age = 42.0
 enabled = true
 works = "toml_example"
 custom = 'this is custom from [default]'
+prefix_custom = "this is custom when we set a prefix"
 
   [default.test_loaders]
   dev = "test_dev"

--- a/example/yaml_example/settings_file/app.py
+++ b/example/yaml_example/settings_file/app.py
@@ -82,7 +82,13 @@ for key, value in assertions.items():
     assert found == getattr(settings.from_env("production"), key)
     assert found == value, f"expected: {key}: [{value}] found: [{found}]"
 
-settings = LazySettings(settings_files=["settings.yaml"], settings_file_prefix="prefix", environments=True)
+settings = LazySettings(
+    settings_files=["settings.yaml"],
+    settings_file_prefix="prefix",
+    environments=True,
+)
 with settings.using_env("default"):
     assert settings.CUSTOM == "this is custom when prefix is set"
-assert settings.from_env("production").CUSTOM == "this is custom when prefix is set"
+assert settings.from_env(
+    "production"
+).CUSTOM == "this is custom when prefix is set"

--- a/example/yaml_example/settings_file/app.py
+++ b/example/yaml_example/settings_file/app.py
@@ -1,4 +1,5 @@
 from dynaconf import settings, LazySettings
+from dynaconf.strategies.filtering import PrefixFilter
 
 # print all values in the file
 # using [default] + [development] + [global] values
@@ -84,7 +85,7 @@ for key, value in assertions.items():
 
 settings = LazySettings(
     settings_files=["settings.yaml"],
-    settings_file_prefix="prefix",
+    filter_strategy=PrefixFilter("prefix"),
     environments=True,
 )
 with settings.using_env("default"):

--- a/example/yaml_example/settings_file/app.py
+++ b/example/yaml_example/settings_file/app.py
@@ -1,4 +1,4 @@
-from dynaconf import settings
+from dynaconf import settings, LazySettings
 
 # print all values in the file
 # using [default] + [development] + [global] values
@@ -51,6 +51,7 @@ assertions = {
     "ENABLED": True,
     "WORKS": "yaml_example in dev env",
     "CUSTOM": "this is custom from [development]",
+    "PREFIX_CUSTOM": "this is custom when prefix is set",
     "TEST_LOADERS": {"dev": "test_dev", "prod": "test_prod"},
 }
 
@@ -71,6 +72,7 @@ assertions = {
     "ENABLED": True,
     "WORKS": "yaml_example in prod env",
     "CUSTOM": "this is custom from [production]",
+    "PREFIX_CUSTOM": "this is custom when prefix is set",
     "TEST_LOADERS": {"dev": "test_dev", "prod": "test_prod"},
 }
 
@@ -79,3 +81,8 @@ for key, value in assertions.items():
     found = settings.from_env("production").get(key)
     assert found == getattr(settings.from_env("production"), key)
     assert found == value, f"expected: {key}: [{value}] found: [{found}]"
+
+settings = LazySettings(settings_files=["settings.yaml"], settings_file_prefix="prefix", environments=True)
+with settings.using_env("default"):
+    assert settings.CUSTOM == "this is custom when prefix is set"
+assert settings.from_env("production").CUSTOM == "this is custom when prefix is set"

--- a/example/yaml_example/settings_file/settings.yaml
+++ b/example/yaml_example/settings_file/settings.yaml
@@ -12,6 +12,7 @@ default:
   enabled: true
   works: yaml_example
   custom: 'this is custom from [default]'
+  prefix_custom: "this is custom when prefix is set"
   test_loaders:
     dev: test_dev
     prod: test_prod

--- a/example/yaml_example/yaml_as_extra_config/app.py
+++ b/example/yaml_example/yaml_as_extra_config/app.py
@@ -1,4 +1,4 @@
-from dynaconf import settings, LazySettings
+from dynaconf import settings
 
 print(settings.YAML)
 print(settings.HOST)
@@ -34,7 +34,6 @@ assertions = {
     "HOST": "prod_server.com",
     "PORT": 5000,
     "ENVIRONMENT": "this is production",
-    "PREFIX_CUSTOM": "this is custom when prefix is set",
 }
 
 
@@ -42,6 +41,3 @@ for key, value in assertions.items():
     found = settings.from_env("production").get(key)
     assert found == getattr(settings.from_env("production"), key)
     assert found == value, f"expected: {key}: [{value}] found: [{found}]"
-
-settings = LazySettings(settings_file_prefix="prefix")
-assert settings.CUSTOM == "this is custom when prefix is set"

--- a/example/yaml_example/yaml_as_extra_config/app.py
+++ b/example/yaml_example/yaml_as_extra_config/app.py
@@ -1,4 +1,4 @@
-from dynaconf import settings
+from dynaconf import settings, LazySettings
 
 print(settings.YAML)
 print(settings.HOST)
@@ -34,6 +34,7 @@ assertions = {
     "HOST": "prod_server.com",
     "PORT": 5000,
     "ENVIRONMENT": "this is production",
+    "PREFIX_CUSTOM": "this is custom when prefix is set",
 }
 
 
@@ -41,3 +42,6 @@ for key, value in assertions.items():
     found = settings.from_env("production").get(key)
     assert found == getattr(settings.from_env("production"), key)
     assert found == value, f"expected: {key}: [{value}] found: [{found}]"
+
+settings = LazySettings(settings_file_prefix="prefix")
+assert settings.CUSTOM == "this is custom when prefix is set"

--- a/example/yaml_example/yaml_as_extra_config/settings.py
+++ b/example/yaml_example/yaml_as_extra_config/settings.py
@@ -1,4 +1,3 @@
 HOST = "default.com"
 PORT = 9000
-PREFIX_CUSTOM = "this is custom when prefix is set"
 YAML = "extra_settings.yaml"  # DEPRECATED

--- a/example/yaml_example/yaml_as_extra_config/settings.py
+++ b/example/yaml_example/yaml_as_extra_config/settings.py
@@ -1,3 +1,4 @@
 HOST = "default.com"
 PORT = 9000
+PREFIX_CUSTOM = "this is custom when prefix is set"
 YAML = "extra_settings.yaml"  # DEPRECATED

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from dynaconf import Dynaconf
+from dynaconf.strategies.filtering import PrefixFilter
 from dynaconf import LazySettings
 from dynaconf.loaders import toml_loader
 from dynaconf.utils.parse_conf import true_values
@@ -765,7 +766,7 @@ def test_from_env_method_with_prefix(clean_env, tmpdir):
     }
     toml_path = str(tmpdir.join("base_settings.toml"))
     toml_loader.write(toml_path, data, merge=False)
-    settings = LazySettings(settings_file=toml_path, environments=True, settings_file_prefix="prefix")
+    settings = LazySettings(settings_file=toml_path, environments=True, filter_strategy=PrefixFilter("prefix"))
     settings.set("ARBITRARY_KEY", "arbitrary value")
 
     assert settings.VALUE == "From development env"
@@ -892,7 +893,7 @@ def test_envless_mode_with_prefix(tmpdir):
 
     settings = LazySettings(
         settings_file="settings.toml",
-        settings_file_prefix="prefix",
+        filter_strategy=PrefixFilter("prefix")
     )  # already the default
     assert settings.FOO == "bar"
     with pytest.raises(AttributeError):
@@ -960,6 +961,6 @@ def test_settings_dict_like_iteration(tmpdir):
 
 def test_prefix_is_not_str_raises():
     with pytest.raises(TypeError):
-        toml_loader.load(LazySettings(settings_file_prefix=int))
+        toml_loader.load(LazySettings(filter_strategy=PrefixFilter(int)))
     with pytest.raises(TypeError):
-        toml_loader.load(LazySettings(settings_file_prefix=True))
+        toml_loader.load(LazySettings(filter_strategy=PrefixFilter(True)))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -892,7 +892,7 @@ def test_envless_mode_with_prefix(tmpdir):
 
     settings = LazySettings(
         settings_file="settings.toml",
-        SETTINGS_FILE_PREFIX="prefix",
+        settings_file_prefix="prefix",
     )  # already the default
     assert settings.FOO == "bar"
     with pytest.raises(AttributeError):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -842,6 +842,26 @@ def test_envless_mode(tmpdir):
     assert settings.DATABASES.default.port == 8080
 
 
+def test_envless_mode_with_prefix(tmpdir):
+    data = {
+        "prefix_foo": "bar",
+        "hello": "world",
+        "prefix_default": 1,
+        "prefix_databases": {"default": {"port": 8080}},
+    }
+    toml_loader.write(str(tmpdir.join("settings.toml")), data)
+
+    settings = LazySettings(
+        settings_file="settings.toml",
+        SETTINGS_FILE_PREFIX="prefix",
+    )  # already the default
+    assert settings.FOO == "bar"
+    with pytest.raises(AttributeError):
+        settings.HELLO
+    assert settings.DEFAULT == 1
+    assert settings.DATABASES.default.port == 8080
+
+
 def test_lowercase_read_mode(tmpdir):
     """
     Starting on 3.0.0 lowercase keys are enabled by default

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -956,3 +956,10 @@ def test_settings_dict_like_iteration(tmpdir):
 
     for key, value in settings.items():
         assert settings._store[key] == value
+
+
+def test_prefix_is_not_str_raises():
+    with pytest.raises(TypeError):
+        toml_loader.load(LazySettings(settings_file_prefix=int))
+    with pytest.raises(TypeError):
+        toml_loader.load(LazySettings(settings_file_prefix=True))

--- a/tests/test_ini_loader.py
+++ b/tests/test_ini_loader.py
@@ -189,3 +189,17 @@ def test_envless():
     assert settings.a == "a,b"
     assert settings.COLORS.white.code == "#FFFFFF"
     assert settings.COLORS.white.name == "white"
+
+
+def test_prefix():
+    settings = LazySettings(settings_file_prefix="prefix")
+    ini = """
+    prefix_a = "a,b"
+    prefix_colors__white__code = '#FFFFFF'
+    COLORS__white__name = 'white'
+    """
+    load(settings, filename=ini)
+    assert settings.a == "a,b"
+    assert settings.COLORS.white.code == "#FFFFFF"
+    with pytest.raises(AttributeError):
+        settings.COLORS.white.name

--- a/tests/test_ini_loader.py
+++ b/tests/test_ini_loader.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dynaconf import LazySettings
+from dynaconf.strategies.filtering import PrefixFilter
 from dynaconf.loaders.ini_loader import load
 
 settings = LazySettings(environments=True, ENV_FOR_DYNACONF="PRODUCTION")
@@ -192,7 +193,7 @@ def test_envless():
 
 
 def test_prefix():
-    settings = LazySettings(settings_file_prefix="prefix")
+    settings = LazySettings(filter_strategy=PrefixFilter("prefix"))
     ini = """
     prefix_a = "a,b"
     prefix_colors__white__code = '#FFFFFF'

--- a/tests/test_json_loader.py
+++ b/tests/test_json_loader.py
@@ -212,3 +212,17 @@ def test_envless():
     load(settings, filename=_json)
     assert settings.COLORS.yellow.code == "#FFCC00"
     assert settings.COLORS.yellow.name == "Yellow"
+
+
+def test_prefix():
+    settings = LazySettings(settings_file_prefix="prefix")
+    _json = """
+    {
+        "prefix_colors__yellow__code": "#FFCC00",
+        "COLORS__yellow__name": "Yellow"
+    }
+    """
+    load(settings, filename=_json)
+    assert settings.COLORS.yellow.code == "#FFCC00"
+    with pytest.raises(AttributeError):
+        settings.COLORS.yellow.name

--- a/tests/test_json_loader.py
+++ b/tests/test_json_loader.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from dynaconf import LazySettings
+from dynaconf.strategies.filtering import PrefixFilter
 from dynaconf.loaders.json_loader import DynaconfEncoder
 from dynaconf.loaders.json_loader import load
 
@@ -215,7 +216,7 @@ def test_envless():
 
 
 def test_prefix():
-    settings = LazySettings(settings_file_prefix="prefix")
+    settings = LazySettings(filter_strategy=PrefixFilter("prefix"))
     _json = """
     {
         "prefix_colors__yellow__code": "#FFCC00",

--- a/tests/test_toml_loader.py
+++ b/tests/test_toml_loader.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dynaconf import LazySettings
+from dynaconf.strategies.filtering import PrefixFilter
 from dynaconf.loaders.toml_loader import encode_nulls
 from dynaconf.loaders.toml_loader import load
 
@@ -209,7 +210,7 @@ def test_envless():
 
 
 def test_prefix():
-    settings = LazySettings(settings_file_prefix="prefix")
+    settings = LazySettings(filter_strategy=PrefixFilter("prefix"))
     ini = """
     prefix_a = "a,b"
     prefix_colors__white__code = '#FFFFFF'

--- a/tests/test_toml_loader.py
+++ b/tests/test_toml_loader.py
@@ -206,3 +206,17 @@ def test_envless():
     assert settings.a == "a,b"
     assert settings.COLORS.white.code == "#FFFFFF"
     assert settings.COLORS.white.name == "white"
+
+
+def test_prefix():
+    settings = LazySettings(settings_file_prefix="prefix")
+    ini = """
+    prefix_a = "a,b"
+    prefix_colors__white__code = '#FFFFFF'
+    COLORS__white__name = 'white'
+    """
+    load(settings, filename=ini)
+    assert settings.a == "a,b"
+    assert settings.COLORS.white.code == "#FFFFFF"
+    with pytest.raises(AttributeError):
+        settings.COLORS.white.name

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from dynaconf import LazySettings
+from dynaconf.strategies.filtering import PrefixFilter
 from dynaconf.loaders.yaml_loader import load
 
 settings = LazySettings(
@@ -298,7 +299,7 @@ def test_envless():
 
 
 def test_prefix():
-    settings = LazySettings(settings_file_prefix="prefix")
+    settings = LazySettings(filter_strategy=PrefixFilter("prefix"))
     _yaml = """
     prefix_a: a,b
     prefix_colors__white__code: "#FFFFFF"

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -297,6 +297,20 @@ def test_envless():
     assert settings.COLORS.white.name == "white"
 
 
+def test_prefix():
+    settings = LazySettings(settings_file_prefix="prefix")
+    _yaml = """
+    prefix_a: a,b
+    prefix_colors__white__code: "#FFFFFF"
+    COLORS__white__name: "white"
+    """
+    load(settings, filename=_yaml)
+    assert settings.a == "a,b"
+    assert settings.COLORS.white.code == "#FFFFFF"
+    with pytest.raises(AttributeError):
+        settings.COLORS.white.name
+
+
 def test_empty_env():
     settings = LazySettings(environments=True)
     _yaml = """


### PR DESCRIPTION
Related to: #621

This adds a settings_file_prefix option for toml, json, ini and yaml files which works similarly to envvar_prefix, however it defaults to None and does not filter out any keys if it is not set.

If envs are in use it will do the filtering within each env's variables, an example is shown below

```
[default]
PREFIX_EXTRA = "this will supercede if others are set without prefix"

[development]
PREFIX_HOST = "https://example.com/development"
PREFIX_PORT = "8080"
COMMENT = "this will not show when prefix is used"
EXTRA = "will not show"

[production]
PREFIX_HOST = "https://example.com/production"
PORT = "443"
EXTRA = "will not show"
```

When these are loaded up using the `settings_file_prefix="PREFIX"` option you'll get the following:

```
>>> settings.HOST
'https://example.com/development'
>>> settings.PORT
'8080'
>>> settings.COMMENT
AttributeError: 'Settings' object has no attribute 'COMMENT'
```

When switching to production env:
```
>>> with settings.using_env("production"):
...     settings.HOST
...     settings.EXTRA
...     settings.PORT

'https://example.com/production'
'this will supercede if others are set without prefix'
AttributeError: Attribute PORT was deleted, or belongs to different env
```

I think this behaves as you'd expect, looking forward to some feedback as I had to fumble about a bit to learn how everything fits together so no doubt I've done some less than ideal things


Envless load when environments exist in the file will not work in this way as we'd not be able to detect that `settings.PRODUCTION` is an env to filter the prefix from children. I think this is probably expected if loading envless while envs are included in the file - but if it was possible to check if `ENVIRONMENTS_FOR_DYNACONF` is False *and* detect that the top level key is an environment (`[production]`) then it may be possible, but I could not see an obvious way to detect that `production` is an environment

