### PR TITLE
Add a warning if `--env` is passed to `init`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,18 +18,22 @@ Usage: dynaconf [OPTIONS] COMMAND [ARGS]...
 
   Dynaconf - Command Line Interface
 
+  Documentation: https://dynaconf.com/
+
 Options:
-  --version  Show dynaconf version
-  --docs     Open documentation in browser
-  --banner   Show awesome banner
+  --version            Show dynaconf version
+  --docs               Open documentation in browser
+  --banner             Show awesome banner
   -i, --instance TEXT  Custom instance of LazySettings
-  --help     Show this message and exit.
+  --help               Show this message and exit.
 
 Commands:
-  init      Inits a dynaconf project By default it...
-  list      Lists all defined config values
+  init      Inits a dynaconf project By default it creates a settings.toml...
+  list      Lists all user defined config values and if `--all` is passed
+            it...
+
+  validate  Validates Dynaconf settings based on rules defined in...
   write     Writes data to specific source
-  validate  Validates based on dynaconf_validators.toml file
 ```
 
 ### dynaconf init
@@ -93,23 +97,22 @@ Usage: dynaconf init [OPTIONS]
   This command must run on the project's root folder or you must pass
   --path=/myproject/root/folder.
 
-  If you want to have a .env created with the ENV defined there e.g:
-  `ENV_FOR_DYNACONF=production` just pass --env=production and then .env
-  will also be created and the env defined to production.
+  The --env/-e is deprecated (kept for compatibility but unused)
 
 Options:
   -f, --format [ini|toml|yaml|json|py|env]
   -p, --path TEXT                 defaults to current directory
   -e, --env TEXT                  Sets the working env in `.env` file
-  -v, --vars TEXT                 extra values to write to settings file file
-                                  e.g: `dynaconf init -v NAME=foo -v X=2
+  -v, --vars TEXT                 extra values to write to settings file e.g:
+                                  `dynaconf init -v NAME=foo -v X=2
+
   -s, --secrets TEXT              secret key values to be written in .secrets
                                   e.g: `dynaconf init -s TOKEN=kdslmflds
+
   --wg / --no-wg
   -y
   --django TEXT
   --help                          Show this message and exit.
-
 ```
 
 ### dynaconf list
@@ -150,19 +153,22 @@ dynaconf list -o path/to/file.py --output-flat
 ### dynaconf write
 
 ```
-Usage: dynaconf write [OPTIONS] TO
+Usage: dynaconf write [OPTIONS] [ini|toml|yaml|json|py|redis|vault|env]
 
   Writes data to specific source
 
 Options:
-  -v, --vars TEXT     key values to be written e.g: `dynaconf write toml
-                      -e NAME=foo -e X=2
+  -v, --vars TEXT     key values to be written e.g: `dynaconf write toml -e
+                      NAME=foo -e X=2
+
   -s, --secrets TEXT  secret key values to be written in .secrets e.g:
                       `dynaconf write toml -s TOKEN=kdslmflds -s X=2
+
   -p, --path TEXT     defaults to current directory/settings.{ext}
   -e, --env TEXT      env to write to defaults to DEVELOPMENT for files for
                       external sources like Redis and Vault it will be
                       DYNACONF or the value set in $ENVVAR_PREFIX_FOR_DYNACONF
+
   -y
   --help              Show this message and exit.
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,10 +40,8 @@ Commands:
 
 Use init to easily configure your application configuration, once dynaconf is installed go to the root directory of your application and run:
 
-creates settings files in current directory
-
 ```
-$ dynaconf -i init -v key=value -v foo=bar -s token=1234 -e production
+$ dynaconf init -v key=value -v foo=bar -s token=1234
 ```
 
 The above command will create in the current directory
@@ -51,11 +49,6 @@ The above command will create in the current directory
 `settings.toml`
 
 ```ini
-[default]
-KEY = "default"
-FOO = "default"
-
-[production]
 KEY = "value"
 FOO = "bar"
 ```
@@ -63,20 +56,10 @@ FOO = "bar"
 also `.secrets.toml`
 
 ```ini
-[default]
-TOKEN = "default"
-
-[production]
 TOKEN = "1234"
 ```
 
-The command will also create a `.env` setting the working environment to **[production]**
-
-```bash
-ENV_FOR_DYNACONF="PRODUCTION"
-```
-
-And will include the `.secrets.toml` in the `.gitignore`
+as well as `.gitignore` file ignoring the generated `.secrets.toml`
 
 ```ini
 # Ignore dynaconf secret files
@@ -114,6 +97,8 @@ Options:
   --django TEXT
   --help                          Show this message and exit.
 ```
+
+Note that `-i`/`--instance` cannot be used with `init` as `-i` must point to an existing instance of the settings.
 
 ### dynaconf list
 

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -206,7 +206,10 @@ def main(ctx, instance):
     "--path", "-p", default=CWD, help="defaults to current directory"
 )
 @click.option(
-    "--env", "-e", default=None, help="Sets the working env in `.env` file"
+    "--env",
+    "-e",
+    default=None,
+    help="deprecated command (kept for compatibility but unused)",
 )
 @click.option(
     "--vars",
@@ -216,7 +219,7 @@ def main(ctx, instance):
     default=None,
     help=(
         "extra values to write to settings file "
-        "e.g: `dynaconf init -v NAME=foo -v X=2"
+        "e.g: `dynaconf init -v NAME=foo -v X=2`"
     ),
 )
 @click.option(

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -216,7 +216,7 @@ def main(ctx, instance):
     default=None,
     help=(
         "extra values to write to settings file "
-        "file e.g: `dynaconf init -v NAME=foo -v X=2"
+        "e.g: `dynaconf init -v NAME=foo -v X=2"
     ),
 )
 @click.option(

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -260,11 +260,11 @@ def init(ctx, fileformat, path, env, _vars, _secrets, wg, y, django):
 
     if env is not None:
         click.secho(
-            "⚠  The --env/-e option is deprecated (kept for\n"
+            "⚠️ The --env/-e option is deprecated (kept for\n"
             "   compatibility but unused)\n",
             fg="red",
             bold=True,
-            stderr=True,
+            # stderr=True,
         )
 
     if settings.get("create_new_settings") is True:

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -251,6 +251,15 @@ def init(ctx, fileformat, path, env, _vars, _secrets, wg, y, django):
     click.echo("-" * 42)
     path = Path(path)
 
+    if env is not None:
+        click.secho(
+            "⚠  The --env/-e option is deprecated (kept for\n"
+            "   compatibility but unused)\n",
+            fg="red",
+            bold=True,
+            stderr=True,
+        )
+
     if settings.get("create_new_settings") is True:
         filename = Path("config.py")
         if not filename.exists():

--- a/dynaconf/cli.py
+++ b/dynaconf/cli.py
@@ -39,6 +39,10 @@ def set_settings(ctx, instance=None):
     settings = None
 
     if instance is not None:
+        if ctx.invoked_subcommand in ["init"]:
+            raise click.UsageError(
+                "-i/--instance option is not allowed for `init` command"
+            )
         sys.path.insert(0, ".")
         settings = import_settings(instance)
     elif "FLASK_APP" in os.environ:  # pragma: no cover

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,25 @@ def test_banner(clean_env):
     assert "Learn more at:" in run(["--banner"])
 
 
+def test_init_with_instance_raises(tmpdir):
+    result = run(
+        [
+            "-i",
+            "tests.test_cli.settings",
+            "init",
+            "--env",
+            "test",
+            f"--path={str(tmpdir)}",
+        ]
+    )
+    assert "-i/--instance option is not allowed for `init` command" in result
+
+
+def test_init_with_env_warns(tmpdir):
+    result = run(["init", "--env", "test", f"--path={str(tmpdir)}"])
+    assert "The --env/-e option is deprecated" in result
+
+
 @pytest.mark.parametrize("fileformat", EXTS)
 def test_init_with_path(fileformat, tmpdir):
     # run twice to force load of existing files


### PR DESCRIPTION
Updated the CLI Click help strings, added in a warning print if `--env/-e` is passed to `init` to mention that it is a deprecated option an has no effect, also added a condition to raise an exception if `dynaconf -i ... init` is called as using instance with the init subcommand doesn't work and the standard exception may not be too clear.

Also updated `docs/cli.md` to be in sync with new help output from the subcommands, and to reflect the deprecation of `dynaconf init --env ...`.

Closes https://github.com/rochacbruno/dynaconf/issues/589