### PR TITLE
description and type annotation for validator

### DIFF
--- a/dynaconf/validator.py
+++ b/dynaconf/validator.py
@@ -1,5 +1,15 @@
+from __future__ import annotations
+
 from itertools import chain
 from types import MappingProxyType
+from typing import Any
+from typing import AnyStr
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
 
 from dynaconf import validator_conditions  # noqa
 from dynaconf.utils import ensure_a_list
@@ -89,16 +99,19 @@ class Validator:
 
     def __init__(
         self,
-        *names,
-        must_exist=None,
-        required=None,  # this is alias for `must_exist`
-        condition=None,
-        when=None,
-        env=None,
-        messages=None,
-        cast=None,
-        default=empty,  # Literal value or a callable
-        **operations
+        *names: List[AnyStr],
+        must_exist: Optional[bool] = None,
+        required: Optional[bool] = None,  # alias for `must_exist`
+        condition: Optional[Callable[[Any], bool]] = None,
+        when: Optional[Validator] = None,
+        env: Optional[Union[AnyStr, List, Tuple]] = None,
+        messages: Optional[Dict[AnyStr, AnyStr]] = None,
+        cast: Optional[AnyStr] = None,
+        default: Optional[
+            Union[Any, Callable[["LazySettings", Validator], Any]]
+        ] = empty,
+        description: Optional[AnyStr] = None,
+        **operations: Optional[Dict[AnyStr, Any]],
     ):
         # Copy immutable MappingProxyType as a mutable dict
         self.messages = dict(self.default_messages)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -5,6 +5,7 @@ import pytest
 from dynaconf import LazySettings
 from dynaconf import ValidationError
 from dynaconf import Validator
+from dynaconf.validator import ValidatorList
 
 
 TOML = """
@@ -614,3 +615,47 @@ def test_raises_on_invalid_selective_args(tmpdir, yaml_validators_good):
     )
     with pytest.raises(ValueError):
         settings.validator_instance.validate()
+
+
+def test_validator_descriptions(tmpdir):
+    validators = ValidatorList(
+        LazySettings(),
+        validators=[
+            Validator("foo", description="foo"),
+            Validator("bar", description="bar"),
+            Validator("baz", "zaz", description="baz zaz"),
+            Validator("foo", description="another message"),
+            Validator("a", description="a") & Validator("b"),
+        ],
+    )
+
+    assert validators.descriptions() == {
+        "bar": ["bar"],
+        "baz": ["baz zaz"],
+        "zaz": ["baz zaz"],
+        "foo": ["foo", "another message"],
+        "a": ["a"],
+        "b": ["a"],
+    }
+
+
+def test_validator_descriptions_flat(tmpdir):
+    validators = ValidatorList(
+        LazySettings(),
+        validators=[
+            Validator("foo", description="foo"),
+            Validator("bar", description="bar"),
+            Validator("baz", "zaz", description="baz zaz"),
+            Validator("foo", description="another message"),
+            Validator("a", description="a") & Validator("b"),
+        ],
+    )
+
+    assert validators.descriptions(flat=True) == {
+        "bar": "bar",
+        "baz": "baz zaz",
+        "zaz": "baz zaz",
+        "foo": "foo",
+        "a": "a",
+        "b": "a",
+    }


### PR DESCRIPTION
Added description to Validator

```py
Validator("foo", description="foo description")
```

Given a ValidatorList one can do.

```py
>>> settings.validators.descriptions(flat=True)
{"foo": "foo description"}
```

Not sure what to do with this yet but the support is added.

Probably the next step is to add a `CLI` to fetch those descriptions and generate/export settings files with descriptions as hints.

Fix: #115 