### PR TITLE
Add unique label when merging lists to fix issue #653

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -918,9 +918,10 @@ class Settings:
             local_merge = (
                 "dynaconf_merge" in value or "dynaconf_merge_unique" in value
             )
+            default_env = self.DEFAULT_ENV_FOR_DYNACONF == "DEFAULT"
             if global_merge or local_merge:
                 value = list(value)
-                unique = False
+                unique = True if default_env else False
                 if local_merge:
                     try:
                         value.remove("dynaconf_merge")


### PR DESCRIPTION
Add boolean variable inside `_merge_before_set()` method to check if the environment was set as default to change the unique bool to True to solve bug when merging two lists described in issue #653.