### PR TITLE
Found this bug that was duplicating the generated envlist

### DIFF
--- a/docs/merging.md
+++ b/docs/merging.md
@@ -192,7 +192,7 @@ settings.SCRIPTS == ['install.sh', 'dev.sh', 'test.sh', 'deploy.sh', 'run.sh']
 ```
 
 > Note that `deploy.sh` is set 3 times but it is not repeated in the final settings.
-
+> **also note** that it avoids duplication but overrides the order of the elements.
 
 ## Local configuration files and merging to existing data
 

--- a/dynaconf/loaders/base.py
+++ b/dynaconf/loaders/base.py
@@ -131,13 +131,9 @@ class BaseLoader:
                 if not data:
                     continue
 
-                if env != self.obj.get("DEFAULT_ENV_FOR_DYNACONF").lower():
-                    identifier = f"{self.identifier}_{env}"
-                else:
-                    identifier = self.identifier
                 self._set_data_to_obj(
                     data,
-                    identifier,
+                    f"{self.identifier}_{env}",
                     file_merge,
                     key,
                 )

--- a/dynaconf/utils/__init__.py
+++ b/dynaconf/utils/__init__.py
@@ -305,27 +305,27 @@ def build_env_list(
         [str] -- A list of string names of the envs to load.
     """
     # add the [default] env
-    env_list = [obj.get("DEFAULT_ENV_FOR_DYNACONF")]
+    env_list = [(obj.get("DEFAULT_ENV_FOR_DYNACONF") or "default").lower()]
 
     # compatibility with older versions that still uses [dynaconf] as
     # [default] env
-    global_env = obj.get("ENVVAR_PREFIX_FOR_DYNACONF") or "DYNACONF"
+    global_env = (obj.get("ENVVAR_PREFIX_FOR_DYNACONF") or "dynaconf").lower()
     if global_env not in env_list:
         env_list.append(global_env)
 
     # add the current env
-    if obj.current_env and obj.current_env not in env_list:
-        env_list.append(obj.current_env)
+    current_env = obj.current_env
+    if current_env and current_env.lower() not in env_list:
+        env_list.append(current_env.lower())
 
     # add a manually set env
-    if env and env not in env_list:
-        env_list.append(env)
+    if env and env.lower() not in env_list:
+        env_list.append(env.lower())
 
     # add the [global] env
-    env_list.append("GLOBAL")
+    env_list.append("global")
 
-    # loaders are responsible to change to lower/upper cases
-    return [env.lower() for env in env_list]
+    return env_list
 
 
 def upperfy(key: str) -> str:

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -80,6 +80,9 @@ class Merge(MetaValue):
     _dynaconf_merge = True
 
     def __init__(self, value, box_settings, unique=False):
+        if unique:
+            self._dynaconf_merge_unique = True
+
         self.box_settings = box_settings
 
         self.value = parse_conf_data(

--- a/example/compat.py
+++ b/example/compat.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 from dynaconf import LazySettings
 from dynaconf.utils import RENAMED_VARS
 
@@ -16,12 +19,19 @@ for old, new in RENAMED_VARS.items():
     assert getattr(settings, new) == getattr(settings, old)
 
 
+tempdir = tempfile.mkdtemp()
+temptoml = tempfile.mktemp(".toml", dir=tempdir)
+temptomlfilename = os.path.basename(temptoml)
+temppy = tempfile.mktemp(".py", dir=tempdir)
+temppyfilename = os.path.basename(temppy)
+
+
 # 0 given a full old-style configured setting
 settings = LazySettings(
     environments=True,
     DYNACONF_NAMESPACE="FOO",
-    DYNACONF_SETTINGS_MODULE="/tmp/foo.toml",
-    PROJECT_ROOT="/tmp/",
+    DYNACONF_SETTINGS_MODULE=str(temptoml),
+    PROJECT_ROOT=str(tempdir),
     DYNACONF_SILENT_ERRORS=False,
     DYNACONF_ALWAYS_FRESH_VARS=["baz", "zaz", "caz"],
     BASE_NAMESPACE_FOR_DYNACONF="original",
@@ -51,8 +61,8 @@ for old, new in RENAMED_VARS.items():
 settings = LazySettings(
     environments=True,
     DYNACONF_NAMESPACE="FOO",
-    DYNACONF_SETTINGS_MODULE="foo.py",
-    PROJECT_ROOT="/tmp",
+    DYNACONF_SETTINGS_MODULE=temppyfilename,
+    PROJECT_ROOT=str(tempdir),
     DYNACONF_SILENT_ERRORS=True,
     DYNACONF_ALWAYS_FRESH_VARS=["BAR"],
     GLOBAL_ENV_FOR_DYNACONF="BLARG",
@@ -60,8 +70,8 @@ settings = LazySettings(
 
 
 assert settings.ENV_FOR_DYNACONF == "FOO"
-assert settings.SETTINGS_FILE_FOR_DYNACONF == "foo.py"
-assert settings.ROOT_PATH_FOR_DYNACONF == "/tmp"
+assert settings.SETTINGS_FILE_FOR_DYNACONF == temppyfilename
+assert settings.ROOT_PATH_FOR_DYNACONF == str(tempdir)
 assert settings.SILENT_ERRORS_FOR_DYNACONF is True
 assert settings.FRESH_VARS_FOR_DYNACONF == ["BAR"]
 assert settings.ENVVAR_PREFIX_FOR_DYNACONF == "BLARG"
@@ -76,16 +86,16 @@ print(settings.FRESH_VARS_FOR_DYNACONF)
 settings = LazySettings(
     environments=True,
     NAMESPACE="FOO",
-    SETTINGS_MODULE="foo.py",
-    PROJECT_ROOT="/tmp",
+    SETTINGS_MODULE=temppyfilename,
+    PROJECT_ROOT=str(tempdir),
     DYNACONF_SILENT_ERRORS=True,
     DYNACONF_ALWAYS_FRESH_VARS=["BAR"],
 )
 
 
 assert settings.ENV_FOR_DYNACONF == "FOO"
-assert settings.SETTINGS_FILE_FOR_DYNACONF == "foo.py"
-assert settings.ROOT_PATH_FOR_DYNACONF == "/tmp"
+assert settings.SETTINGS_FILE_FOR_DYNACONF == temppyfilename
+assert settings.ROOT_PATH_FOR_DYNACONF == str(tempdir)
 assert settings.SILENT_ERRORS_FOR_DYNACONF is True
 assert settings.FRESH_VARS_FOR_DYNACONF == ["BAR"]
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,6 +6,7 @@ import yaml
 from dynaconf import Dynaconf
 from dynaconf import LazySettings
 from dynaconf.loaders import toml_loader
+from dynaconf.loaders import yaml_loader
 from dynaconf.strategies.filtering import PrefixFilter
 from dynaconf.utils.parse_conf import true_values
 from dynaconf.vendor_src.box.box_list import BoxList
@@ -1030,22 +1031,16 @@ def test_wrap_existing_settings_clone():
     assert settings.FOO == "bar"
 
 
-@pytest.fixture()
-def resource():
-    settings_test = {
+def test_list_entries_from_yaml_should_not_duplicate_when_merged(tmpdir):
+    data = {
         "default": {
             "SOME_KEY": "value",
             "SOME_LIST": ["item_1", "item_2", "item_3"],
         },
         "other": {"SOME_KEY": "new_value", "SOME_LIST": ["item_4", "item_5"]},
     }
+    yaml_loader.write(str(tmpdir.join("test_settings.yaml")), data)
 
-    settings_yaml = yaml.dump(settings_test)
-    with open("test_settings.yaml", "w") as file:
-        file.write(settings_yaml)
-
-
-def test_list_entries_from_yaml_should_not_duplicate_when_merged(resource):
     settings = Dynaconf(
         settings_files="test_settings.yaml",
         environments=True,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ import pytest
 
 from dynaconf import default_settings
 from dynaconf.loaders.json_loader import DynaconfEncoder
+from dynaconf.utils import build_env_list
 from dynaconf.utils import ensure_a_list
 from dynaconf.utils import extract_json_objects
 from dynaconf.utils import isnamedtupleinstance
@@ -169,7 +170,6 @@ def test_meta_values(settings):
     reset = parse_conf_data(
         "@reset [1, 2]", tomlfy=True, box_settings=settings
     )
-    # @reset is DEPRECATED in v3.0.0 but kept for backwards compatibility
     assert reset.value == [1, 2]
     assert reset._dynaconf_reset is True
     assert "Reset([1, 2])" in repr(reset)
@@ -373,3 +373,17 @@ def test_extract_json():
     assert list(extract_json_objects('foo bar {"a": 1}')) == [{"a": 1}]
     assert list(extract_json_objects("foo bar {'a': 2{")) == []
     assert list(extract_json_objects('{{{"x": {}}}}')) == [{"x": {}}]
+
+
+def test_env_list():
+    class Obj(dict):
+        @property
+        def current_env(self):
+            return "other"
+
+    assert build_env_list(Obj(), env="OTHER") == [
+        "default",
+        "dynaconf",
+        "other",
+        "global",
+    ]


### PR DESCRIPTION
also stopped using `/tmp` on tests (using tempfile instead)