### PR TITLE
Feature: add @jinja and @format casting

### DIFF
--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -19,7 +19,7 @@ jobs:
           commit-message: Update Contributors
           title: "[automated] Update Contributors File"
           token: ${{ secrets.GITHUB_TOKEN }}
-          
+
 #       - name: Update resources
 #         uses: test-room-7/action-update-file@v1
 #         with:

--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,0 +1,28 @@
+name: Update CONTRIBUTORS file
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: minicli/action-contributors@v3
+        name: "Update a projects CONTRIBUTORS file"
+        env:
+          CONTRIB_REPOSITORY: 'rochacbruno/dynaconf'
+          CONTRIB_OUTPUT_FILE: 'CONTRIBUTORS.md'
+      - name: Create a PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Update Contributors
+          title: "[automated] Update Contributors File"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+#       - name: Update resources
+#         uses: test-room-7/action-update-file@v1
+#         with:
+#           file-path: 'CONTRIBUTORS.md'
+#           commit-msg: Update Contributors
+#           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -234,7 +234,7 @@ converters = {
     if isinstance(value, Lazy) else float(value),
     "@bool": lambda value: value.set_casting(
         lambda x: str(x).lower() in true_values
-    ) 
+    )
     if isinstance(value, Lazy) else str(value).lower() in true_values,
     "@json": lambda value: value.set_casting(
         lambda x: json.loads(x.replace("'", '"'))

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -306,7 +306,7 @@ def _parse_conf_data(data, tomlfy=False, box_settings=None):
     ):
         # Check combination token is used
         comb_token = re.match(
-            r"@(str|int|float|bool|json) @(jinja|format)", data
+            r"^@(str|int|float|bool|json) @(jinja|format)", data
         )
         if comb_token:
             tokens = comb_token.group(0)

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -227,19 +227,24 @@ def evaluate_lazy_format(f):
 
 converters = {
     "@str": lambda value: value.set_casting(str)
-    if isinstance(value, Lazy) else str(value),
+    if isinstance(value, Lazy)
+    else str(value),
     "@int": lambda value: value.set_casting(int)
-    if isinstance(value, Lazy) else int(value),
+    if isinstance(value, Lazy)
+    else int(value),
     "@float": lambda value: value.set_casting(float)
-    if isinstance(value, Lazy) else float(value),
+    if isinstance(value, Lazy)
+    else float(value),
     "@bool": lambda value: value.set_casting(
         lambda x: str(x).lower() in true_values
     )
-    if isinstance(value, Lazy) else str(value).lower() in true_values,
+    if isinstance(value, Lazy)
+    else str(value).lower() in true_values,
     "@json": lambda value: value.set_casting(
         lambda x: json.loads(x.replace("'", '"'))
     )
-    if isinstance(value, Lazy) else json.loads(value),
+    if isinstance(value, Lazy)
+    else json.loads(value),
     "@format": lambda value: Lazy(value),
     "@jinja": lambda value: Lazy(value, formatter=Formatters.jinja_formatter),
     # Meta Values to trigger pre assignment actions

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -244,7 +244,7 @@ converters = {
         lambda x: json.loads(x.replace("'", '"'))
     )
     if isinstance(value, Lazy)
-    else json.loads(value),
+    else json.loads(value.replace("'", '"')),
     "@format": lambda value: Lazy(value),
     "@jinja": lambda value: Lazy(value, formatter=Formatters.jinja_formatter),
     # Meta Values to trigger pre assignment actions

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -60,7 +60,9 @@ class Reset(MetaValue):
 
     def __init__(self, value, box_settings):
         self.box_settings = box_settings
-        self.value = parse_conf_data(value, tomlfy=True, box_settings=self.box_settings)
+        self.value = parse_conf_data(
+            value, tomlfy=True, box_settings=self.box_settings
+        )
         warnings.warn(f"{self.value} does not need `@reset` anymore.")
 
 

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -40,7 +40,9 @@ class MetaValue:
 
     def __init__(self, value, box_settings):
         self.box_settings = box_settings
-        self.value = parse_conf_data(value, tomlfy=True, box_settings=box_settings)
+        self.value = parse_conf_data(
+            value, tomlfy=True, box_settings=box_settings
+        )
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.value}) on {id(self)}"
@@ -82,7 +84,9 @@ class Merge(MetaValue):
 
         self.box_settings = box_settings
 
-        self.value = parse_conf_data(value, tomlfy=True, box_settings=box_settings)
+        self.value = parse_conf_data(
+            value, tomlfy=True, box_settings=box_settings
+        )
 
         if isinstance(self.value, (int, float, bool)):
             # @merge 1, @merge 1.1, @merge False
@@ -114,7 +118,9 @@ class Merge(MetaValue):
                         k.strip(): parse_conf_data(
                             v, tomlfy=True, box_settings=box_settings
                         )
-                        for k, v in (match.strip().split("=") for match in matches)
+                        for k, v in (
+                            match.strip().split("=") for match in matches
+                        )
                     }
                 elif "," in self.value:
                     # @merge foo,bar

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -226,9 +226,12 @@ def evaluate_lazy_format(f):
 
 
 converters = {
-    "@str": lambda value: value.set_casting(str) if isinstance(value, Lazy) else str(value),
-    "@int": lambda value: value.set_casting(int) if isinstance(value, Lazy) else int(value),
-    "@float": lambda value: value.set_casting(float) if isinstance(value, Lazy) else float(value),
+    "@str": lambda value: value.set_casting(str) 
+    if isinstance(value, Lazy) else str(value),
+    "@int": lambda value: value.set_casting(int) 
+    if isinstance(value, Lazy) else int(value),
+    "@float": lambda value: value.set_casting(float) 
+    if isinstance(value, Lazy) else float(value),
     "@bool": lambda value: value.set_casting(lambda x: str(x).lower() in true_values)
     if isinstance(value, Lazy) else str(value).lower() in true_values,
     "@json": lambda value: value.set_casting(lambda x: json.loads(x.replace("'", '"')))

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -304,11 +304,20 @@ def _parse_conf_data(data, tomlfy=False, box_settings=None):
         and isinstance(data, str)
         and data.startswith(tuple(converters.keys()))
     ):
+        # Check combination token is used
+        comb_token = re.match(
+            r"@(str|int|float|bool|json) @(jinja|format)", data
+        )
+        if comb_token:
+            tokens = comb_token.group(0)
+            converter_key_list = tokens.split(" ")
+            value = data.replace(tokens, "").strip()
+        else:
+            parts = data.partition(" ")
+            converter_key_list = [parts[0]]
+            value = parts[-1]
+
         # Parse the converters iteratively
-        num_converters = data.count("@")
-        parts = data.split(" ", num_converters)
-        converter_key_list = parts[:num_converters]
-        value = parts[-1] if len(parts) > 1 else ""  # for @del
         for converter_key in converter_key_list[::-1]:
             value = get_converter(converter_key, value, box_settings)
     else:

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -199,6 +199,11 @@ class Lazy:
         """Encodes this object values to be serializable to json"""
         return f"@{self.formatter} {self.value}"
 
+    def set_casting(self, casting):
+        """Set the casting and return the instance."""
+        self.casting = casting
+        return self
+
 
 def try_to_encode(value, callback=str):
     """Tries to encode a value by verifying existence of `_dynaconf_encode`"""
@@ -221,29 +226,15 @@ def evaluate_lazy_format(f):
 
 
 converters = {
-    "@str": str,
-    "@int": int,
-    "@float": float,
-    "@bool": lambda value: str(value).lower() in true_values,
-    "@json": json.loads,
+    "@str": lambda value: value.set_casting(str) if isinstance(value, Lazy) else str(value),
+    "@int": lambda value: value.set_casting(int) if isinstance(value, Lazy) else int(value),
+    "@float": lambda value: value.set_casting(float) if isinstance(value, Lazy) else float(value),
+    "@bool": lambda value: value.set_casting(lambda x: str(x).lower() in true_values) 
+        if isinstance(value, Lazy) else str(value).lower() in true_values,
+    "@json": lambda value: value.set_casting(lambda x: json.loads(x.replace("'", '"'))) 
+        if isinstance(value, Lazy) else json.loads(value),
     "@format": lambda value: Lazy(value),
     "@jinja": lambda value: Lazy(value, formatter=Formatters.jinja_formatter),
-    "@jinja_int": lambda value: Lazy(
-        value, formatter=Formatters.jinja_formatter, casting=int
-    ),
-    "@jinja_float": lambda value: Lazy(
-        value, formatter=Formatters.jinja_formatter, casting=float
-    ),
-    "@jinja_bool": lambda value: Lazy(
-        value,
-        formatter=Formatters.jinja_formatter,
-        casting=lambda value: str(value).lower() in true_values,
-    ),
-    "@jinja_json": lambda value: Lazy(
-        value,
-        formatter=Formatters.jinja_formatter,
-        casting=lambda x: json.loads(x.replace("'", '"')),
-    ),
     # Meta Values to trigger pre assignment actions
     "@reset": Reset,  # @reset is DEPRECATED on v3.0.0
     "@del": Del,
@@ -301,10 +292,13 @@ def _parse_conf_data(data, tomlfy=False, box_settings=None):
         and isinstance(data, str)
         and data.startswith(tuple(converters.keys()))
     ):
-        parts = data.partition(" ")
-        converter_key = parts[0]
-        value = parts[-1]
-        value = get_converter(converter_key, value, box_settings)
+        # Parse the converters iteratively
+        num_converters = data.count("@")
+        parts = data.split(" ", num_converters)
+        converter_key_list = parts[:num_converters]
+        value = parts[-1] if len(parts) > 1 else "" # for @del
+        for converter_key in converter_key_list[::-1]:
+            value = get_converter(converter_key, value, box_settings)
     else:
         value = parse_with_toml(data) if tomlfy else data
 

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -244,7 +244,7 @@ converters = {
         lambda x: json.loads(x.replace("'", '"'))
     )
     if isinstance(value, Lazy)
-    else json.loads(value.replace("'", '"')),
+    else json.loads(value),
     "@format": lambda value: Lazy(value),
     "@jinja": lambda value: Lazy(value, formatter=Formatters.jinja_formatter),
     # Meta Values to trigger pre assignment actions

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -226,15 +226,19 @@ def evaluate_lazy_format(f):
 
 
 converters = {
-    "@str": lambda value: value.set_casting(str) 
+    "@str": lambda value: value.set_casting(str)
     if isinstance(value, Lazy) else str(value),
-    "@int": lambda value: value.set_casting(int) 
+    "@int": lambda value: value.set_casting(int)
     if isinstance(value, Lazy) else int(value),
-    "@float": lambda value: value.set_casting(float) 
+    "@float": lambda value: value.set_casting(float)
     if isinstance(value, Lazy) else float(value),
-    "@bool": lambda value: value.set_casting(lambda x: str(x).lower() in true_values)
+    "@bool": lambda value: value.set_casting(
+        lambda x: str(x).lower() in true_values
+    ) 
     if isinstance(value, Lazy) else str(value).lower() in true_values,
-    "@json": lambda value: value.set_casting(lambda x: json.loads(x.replace("'", '"')))
+    "@json": lambda value: value.set_casting(
+        lambda x: json.loads(x.replace("'", '"'))
+    )
     if isinstance(value, Lazy) else json.loads(value),
     "@format": lambda value: Lazy(value),
     "@jinja": lambda value: Lazy(value, formatter=Formatters.jinja_formatter),

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -229,10 +229,10 @@ converters = {
     "@str": lambda value: value.set_casting(str) if isinstance(value, Lazy) else str(value),
     "@int": lambda value: value.set_casting(int) if isinstance(value, Lazy) else int(value),
     "@float": lambda value: value.set_casting(float) if isinstance(value, Lazy) else float(value),
-    "@bool": lambda value: value.set_casting(lambda x: str(x).lower() in true_values) 
-        if isinstance(value, Lazy) else str(value).lower() in true_values,
-    "@json": lambda value: value.set_casting(lambda x: json.loads(x.replace("'", '"'))) 
-        if isinstance(value, Lazy) else json.loads(value),
+    "@bool": lambda value: value.set_casting(lambda x: str(x).lower() in true_values)
+    if isinstance(value, Lazy) else str(value).lower() in true_values,
+    "@json": lambda value: value.set_casting(lambda x: json.loads(x.replace("'", '"')))
+    if isinstance(value, Lazy) else json.loads(value),
     "@format": lambda value: Lazy(value),
     "@jinja": lambda value: Lazy(value, formatter=Formatters.jinja_formatter),
     # Meta Values to trigger pre assignment actions
@@ -296,7 +296,7 @@ def _parse_conf_data(data, tomlfy=False, box_settings=None):
         num_converters = data.count("@")
         parts = data.split(" ", num_converters)
         converter_key_list = parts[:num_converters]
-        value = parts[-1] if len(parts) > 1 else "" # for @del
+        value = parts[-1] if len(parts) > 1 else ""  # for @del
         for converter_key in converter_key_list[::-1]:
             value = get_converter(converter_key, value, box_settings)
     else:

--- a/dynaconf/utils/parse_conf.py
+++ b/dynaconf/utils/parse_conf.py
@@ -40,9 +40,7 @@ class MetaValue:
 
     def __init__(self, value, box_settings):
         self.box_settings = box_settings
-        self.value = parse_conf_data(
-            value, tomlfy=True, box_settings=box_settings
-        )
+        self.value = parse_conf_data(value, tomlfy=True, box_settings=box_settings)
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.value}) on {id(self)}"
@@ -60,9 +58,7 @@ class Reset(MetaValue):
 
     def __init__(self, value, box_settings):
         self.box_settings = box_settings
-        self.value = parse_conf_data(
-            value, tomlfy=True, box_settings=self.box_settings
-        )
+        self.value = parse_conf_data(value, tomlfy=True, box_settings=self.box_settings)
         warnings.warn(f"{self.value} does not need `@reset` anymore.")
 
 
@@ -86,9 +82,7 @@ class Merge(MetaValue):
 
         self.box_settings = box_settings
 
-        self.value = parse_conf_data(
-            value, tomlfy=True, box_settings=box_settings
-        )
+        self.value = parse_conf_data(value, tomlfy=True, box_settings=box_settings)
 
         if isinstance(self.value, (int, float, bool)):
             # @merge 1, @merge 1.1, @merge False
@@ -120,9 +114,7 @@ class Merge(MetaValue):
                         k.strip(): parse_conf_data(
                             v, tomlfy=True, box_settings=box_settings
                         )
-                        for k, v in (
-                            match.strip().split("=") for match in matches
-                        )
+                        for k, v in (match.strip().split("=") for match in matches)
                     }
                 elif "," in self.value:
                     # @merge foo,bar
@@ -166,7 +158,9 @@ class Lazy:
 
     _dynaconf_lazy_format = True
 
-    def __init__(self, value=empty, formatter=Formatters.python_formatter, casting=None):
+    def __init__(
+        self, value=empty, formatter=Formatters.python_formatter, casting=None
+    ):
         self.value = value
         self.formatter = formatter
         self.casting = casting
@@ -226,10 +220,22 @@ converters = {
     "@json": json.loads,
     "@format": lambda value: Lazy(value),
     "@jinja": lambda value: Lazy(value, formatter=Formatters.jinja_formatter),
-    "@jinja_int": lambda value: Lazy(value, formatter=Formatters.jinja_formatter, casting=int),
-    "@jinja_float": lambda value: Lazy(value, formatter=Formatters.jinja_formatter, casting=float),
-    "@jinja_bool": lambda value: Lazy(value, formatter=Formatters.jinja_formatter, casting=lambda value: str(value).lower() in true_values),
-    "@jinja_json": lambda value: Lazy(value, formatter=Formatters.jinja_formatter, casting=lambda x: json.loads(x.replace("'", '"'))),
+    "@jinja_int": lambda value: Lazy(
+        value, formatter=Formatters.jinja_formatter, casting=int
+    ),
+    "@jinja_float": lambda value: Lazy(
+        value, formatter=Formatters.jinja_formatter, casting=float
+    ),
+    "@jinja_bool": lambda value: Lazy(
+        value,
+        formatter=Formatters.jinja_formatter,
+        casting=lambda value: str(value).lower() in true_values,
+    ),
+    "@jinja_json": lambda value: Lazy(
+        value,
+        formatter=Formatters.jinja_formatter,
+        casting=lambda x: json.loads(x.replace("'", '"')),
+    ),
     # Meta Values to trigger pre assignment actions
     "@reset": Reset,  # @reset is DEPRECATED on v3.0.0
     "@del": Del,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,8 +121,10 @@ def test_jinja_casting_bool():
 
 
 def test_jinja_casting_json():
-    res = parse_conf_data("@jinja_json {{ this.value }}")({"value": "{'FOO': 'bar'}"})
-    assert isinstance(res, dict) 
+    res = parse_conf_data("@jinja_json {{ this.value }}")(
+        {"value": "{'FOO': 'bar'}"}
+    )
+    assert isinstance(res, dict)
     assert "FOO" in res and "bar" in res.values()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,19 +106,23 @@ def test_find_file(tmpdir):
 
 def test_jinja_casting_int():
     res = parse_conf_data("@jinja_int {{ this.value }}")({"value": 2})
-    assert isinstance(res, int) and res == 2 
+    assert isinstance(res, int) and res == 2
+
 
 def test_jinja_casting_float():
     res = parse_conf_data("@jinja_float {{ this.value }}")({"value": 0.3})
-    assert isinstance(res, float) and abs(res - 0.3) < 1E-6 
+    assert isinstance(res, float) and abs(res - 0.3) < 1e-6
+
 
 def test_jinja_casting_bool():
     res = parse_conf_data("@jinja_bool {{ this.value }}")({"value": "true"})
-    assert isinstance(res, bool) and res == True 
+    assert isinstance(res, bool) and res == True
+
 
 def test_jinja_casting_json():
     res = parse_conf_data("@jinja_json {{ this.value }}")({"value": "{'FOO': 'bar'}"})
-    assert isinstance(res, dict) and "FOO" in res and "bar" in res.values() 
+    assert isinstance(res, dict) and "FOO" in res and "bar" in res.values()
+
 
 def test_disable_cast(monkeypatch):
     # this casts for int

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,6 +104,7 @@ def test_find_file(tmpdir):
         project_root=str(child4), skip_files=[filename]
     ) == os.path.join(str(tmpdir), ".env")
 
+
 def test_jinja_casting_int():
     res = parse_conf_data("@jinja_int {{ this.value }}")({"value": 2})
     assert isinstance(res, int) and res == 2
@@ -116,12 +117,13 @@ def test_jinja_casting_float():
 
 def test_jinja_casting_bool():
     res = parse_conf_data("@jinja_bool {{ this.value }}")({"value": "true"})
-    assert isinstance(res, bool) and res == True
+    assert isinstance(res, bool) and res is True
 
 
 def test_jinja_casting_json():
     res = parse_conf_data("@jinja_json {{ this.value }}")({"value": "{'FOO': 'bar'}"})
-    assert isinstance(res, dict) and "FOO" in res and "bar" in res.values()
+    assert isinstance(res, dict) 
+    assert "FOO" in res and "bar" in res.values()
 
 
 def test_disable_cast(monkeypatch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,6 +104,22 @@ def test_find_file(tmpdir):
         project_root=str(child4), skip_files=[filename]
     ) == os.path.join(str(tmpdir), ".env")
 
+def test_jinja_casting_int():
+    res = parse_conf_data("@jinja_int {{ this.value }}")({"value": 2})
+    assert isinstance(res, int) and res == 2 
+
+def test_jinja_casting_float():
+    res = parse_conf_data("@jinja_float {{ this.value }}")({"value": 0.3})
+    assert isinstance(res, float) and abs(res - 0.3) < 1E-6 
+
+def test_jinja_casting_bool():
+    res = parse_conf_data("@jinja_bool {{ this.value }}")({"value": "true"})
+    assert isinstance(res, bool) and res == True 
+
+def test_jinja_casting_json():
+    res = parse_conf_data("@jinja_json {{ this.value }}")({"value": "{'FOO': 'bar'}"})
+    assert isinstance(res, dict) and "FOO" in res and "bar" in res.values() 
+
 
 def test_disable_cast(monkeypatch):
     # this casts for int

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -120,7 +120,6 @@ def test_jinja_casting_json():
     res = parse_conf_data("@jinja_json {{ this.value }}")({"value": "{'FOO': 'bar'}"})
     assert isinstance(res, dict) and "FOO" in res and "bar" in res.values() 
 
-
 def test_disable_cast(monkeypatch):
     # this casts for int
     assert parse_conf_data("@int 42", box_settings={}) == 42

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,25 +105,66 @@ def test_find_file(tmpdir):
     ) == os.path.join(str(tmpdir), ".env")
 
 
-def test_jinja_casting_int():
-    res = parse_conf_data("@jinja_int {{ this.value }}")({"value": 2})
+def test_casting_str(settings):
+    res = parse_conf_data("@str 7")
+    assert isinstance(res, str) and res == "7"
+
+    settings.set("value", 7)
+    res = parse_conf_data("@str @jinja {{ this.value }}")(settings)
+    assert isinstance(res, str) and res == "7"
+
+    res = parse_conf_data("@str @format {this.value}")(settings)
+    assert isinstance(res, str) and res == "7"
+
+
+def test_casting_int(settings):
+    res = parse_conf_data("@int 2")
+    assert isinstance(res, int) and res == 2
+
+    settings.set("value", 2)
+    res = parse_conf_data("@int @jinja {{ this.value }}")(settings)
+    assert isinstance(res, int) and res == 2
+
+    res = parse_conf_data("@int @format {this.value}")(settings)
     assert isinstance(res, int) and res == 2
 
 
-def test_jinja_casting_float():
-    res = parse_conf_data("@jinja_float {{ this.value }}")({"value": 0.3})
+def test_casting_float(settings):
+    res = parse_conf_data("@float 0.3")
+    assert isinstance(res, float) and abs(res - 0.3) < 1e-6
+
+    settings.set("value", 0.3)
+    res = parse_conf_data("@float @jinja {{ this.value }}")(settings)
+    assert isinstance(res, float) and abs(res - 0.3) < 1e-6
+
+    res = parse_conf_data("@float @format {this.value}")(settings)
     assert isinstance(res, float) and abs(res - 0.3) < 1e-6
 
 
-def test_jinja_casting_bool():
-    res = parse_conf_data("@jinja_bool {{ this.value }}")({"value": "true"})
+def test_casting_bool(settings):
+    res = parse_conf_data("@bool true")
     assert isinstance(res, bool) and res is True
 
+    settings.set("value", "true")
+    res = parse_conf_data("@bool @jinja {{ this.value }}")(settings)
+    assert isinstance(res, bool) and res is True
 
-def test_jinja_casting_json():
-    res = parse_conf_data("@jinja_json {{ this.value }}")(
-        {"value": "{'FOO': 'bar'}"}
-    )
+    settings.set("value", "false")
+    res = parse_conf_data("@bool @format {this.value}")(settings)
+    assert isinstance(res, bool) and res is False
+
+
+def test_casting_json(settings):
+    res = parse_conf_data("@json {'FOO': 'bar'}")
+    assert isinstance(res, dict)
+    assert "FOO" in res and "bar" in res.values()
+
+    settings.set("value", "{'FOO': 'bar'}")
+    res = parse_conf_data("@json @jinja {{ this.value }}")(settings)
+    assert isinstance(res, dict)
+    assert "FOO" in res and "bar" in res.values()
+
+    res = parse_conf_data("@json @format {this.value}")(settings)
     assert isinstance(res, dict)
     assert "FOO" in res and "bar" in res.values()
 


### PR DESCRIPTION
# Adding the capability of `@jinja` and `@format` templated values to be type-casted

Related to issue: #642 

* Implemented the following casting cases that are compatible with `@jinja` and `@format`:
    - `@str`: casting parsed results to string
    - `@int`: casting parsed results to integer
    - `@float`: casting parsed results to float
    - `@bool`: casting parsed results to boolean
    - `@json`: casting parsed results to dictionary
* Updated `Lazy` class under `utils/parse_conf.py`
    - Added the `casting` argument
    - Adding the method `set_casting(self, casting)`
* Added the unit test for the above casting.

# Examples

## Casting to integer from Jinja templated values

```yaml
NUM_GPUS: 4
# This returns the integer after parsing
FOO: "@int @jinja {{ this.NUM_GPUS }}"
# This returns the string after parsing
FOO: "@jinja {{ this.NUM_GPUS }}"
```

## Casting to a json dict from Jinja templated values

```yaml
MODEL_1:
  MODEL_PATH: "src.main.models.CNNModel"
  GPU_COUNT: 4
  OPTIMIZER_KWARGS:
    learning_rate: 0.002

MODEL_2:
  MODEL_PATH: "src.main.models.VGGModel"
  GPU_COUNT: 2
  OPTIMIZER_KWARGS:
    learning_rate: 0.001

# Flag to choose which model to use
MODEL_TYPE: "MODEL_2"

# This returns the dict loaded from the resulting json
MODEL_SETTINGS: "@json @jinja {{ this|attr(this.MODEL_TYPE) }}"

# This returns the raw json string
MODEL_SETTINGS: "@jinja {{ this|attr(this.MODEL_TYPE) }}"
```