### PR TITLE
Fix FlaskConfig.setdefault

### DIFF
--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -19,7 +19,7 @@ jobs:
           commit-message: Update Contributors
           title: "[automated] Update Contributors File"
           token: ${{ secrets.GITHUB_TOKEN }}
-          
+
 #       - name: Update resources
 #         uses: test-room-7/action-update-file@v1
 #         with:

--- a/dynaconf/contrib/flask_dynaconf.py
+++ b/dynaconf/contrib/flask_dynaconf.py
@@ -178,6 +178,9 @@ class DynaconfConfig(Config):
     def items(self):
         return self._chain_map().items()
 
+    def setdefault(self, key, value=None):
+        return self._chain_map().setdefault(key, value)
+
     def __iter__(self):
         return self._chain_map().__iter__()
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -109,6 +109,10 @@ def test_flask_dynaconf(settings):
     assert "bar" in app.config.values()
     assert "MY_VAR" in list(app.config)
     assert "MY_VAR2" in list(app.config)
+    assert app.config.setdefault("MY_VAR", "default") == "foo"
+    assert app.config.setdefault("MY_VAR2", "default") == "bar"
+    assert app.config.setdefault("DEFAULT_VAR", "default") == "default"
+    assert app.config["DEFAULT_VAR"] == "default"
 
     with pytest.raises(KeyError):
         app.config["NONEXISTENETVAR"]


### PR DESCRIPTION
Currently, it only checks the underlying dict but not the Dynaconf instance, resulting in the wrong return value if the key exists in the Dynaconf instance.