### PR TITLE
Makes Django/Flask kwargs case insensitive

### DIFF
--- a/docs/flask.md
+++ b/docs/flask.md
@@ -51,7 +51,7 @@ export PEANUT_MAIL_SERVER='host.com'  # app.config.get('MAIL_SERVER')
 ```
 
 !!! info
-    Version 3.1.7 backwads was case sensitive on defining `ENVVAR_PREFIX` and would only accept uppsercase kwargs (different from `Dynaconf(envvar_prefix)`). Starting from version X.X.X, kwargs should be case insensitive to improve consistency between Dynaconf and Flask/Django extensions, while keeping backwards compatibility.
+    Version 3.1.7 backwards was case sensitive on defining `ENVVAR_PREFIX` and would only accept uppsercase kwargs (different from `Dynaconf(envvar_prefix)`). Starting from version X.X.X, kwargs should be case insensitive to improve consistency between Dynaconf and Flask/Django extensions, while keeping backwards compatibility.
 
 ## Settings files
 

--- a/docs/flask.md
+++ b/docs/flask.md
@@ -33,6 +33,7 @@ export FLASK_MAIL_SERVER='host.com'  # app.config.get('MAIL_SERVER')
 You can also leverage custom environment variables just as in the default Dynaconf class, like so:
 
 Example:
+
 ```python
 from flask import Flask
 from dynaconf import FlaskDynaconf

--- a/docs/flask.md
+++ b/docs/flask.md
@@ -30,6 +30,28 @@ export FLASK_INTVALUE=1              # app.config['INTVALUE']
 export FLASK_MAIL_SERVER='host.com'  # app.config.get('MAIL_SERVER')
 ```
 
+You can also leverage custom environment variables just as in the default Dynaconf class, like so:
+
+Example:
+```python
+from flask import Flask
+from dynaconf import FlaskDynaconf
+
+app = Flask(__name__)
+FlaskDynaconf(app, envvar_prefix="PEANUT")
+```
+
+Now you can declare your variables with your custom prefix, and it will be normally available withing Flask's native configuration `app.config`.
+
+```bash
+export PEANUT_DEBUG=true              # app.config.DEBUG
+export PEANUT_INTVALUE=1              # app.config['INTVALUE']
+export PEANUT_MAIL_SERVER='host.com'  # app.config.get('MAIL_SERVER')
+```
+
+!!! info
+    Version 3.1.7 backwads was case sensitive on defining `ENVVAR_PREFIX` and would only accept uppsercase kwargs (different from `Dynaconf(envvar_prefix)`). Starting from version X.X.X, kwargs should be case insensitive to improve consistency between Dynaconf and Flask/Django extensions, while keeping backwards compatibility.
+
 ## Settings files
 
 You can also have settings files for your Flask app, in the root directory (the same where you execute `flask run`) put your `settings.toml` and `.secrets.toml` files and then define your environments `[default]`, `[development]` and `[production]`.
@@ -40,7 +62,6 @@ in development mode or `FLASK_ENV=production` to switch to production.
 > **IMPORTANT**: To use `$ dynaconf` CLI the `FLASK_APP` must be defined.
 
 IF you don't want to manually create your config files take a look at the [CLI](/cli/)
-
 
 ## Loading Flask Extensions Dynamically
 
@@ -90,7 +111,6 @@ export FLASK_EXTENSIONS="['flask_admin:Admin']"
 ```
 
 The extensions will be loaded in order.
-
 
 ### Development extensions
 

--- a/dynaconf/contrib/django_dynaconf_v2.py
+++ b/dynaconf/contrib/django_dynaconf_v2.py
@@ -54,7 +54,9 @@ def load(django_settings_module_name=None, **kwargs):  # pragma: no cover
 
     # 1) Create the lazy settings object reusing settings_module consts
     options = {
-        k: v for k, v in django_settings_module.__dict__.items() if k.isupper()
+        k.upper(): v
+        for k, v in django_settings_module.__dict__.items()
+        if k.isupper()
     }
     options.update(kwargs)
     options.setdefault(

--- a/dynaconf/contrib/flask_dynaconf.py
+++ b/dynaconf/contrib/flask_dynaconf.py
@@ -90,8 +90,7 @@ class FlaskDynaconf:
                 "To use this extension Flask must be installed "
                 "install it with: pip install flask"
             )
-        self.kwargs = kwargs
-
+        self.kwargs = {k.upper(): v for k, v in kwargs.items()}
         kwargs.setdefault("ENVVAR_PREFIX", "FLASK")
         env_prefix = f"{kwargs['ENVVAR_PREFIX']}_ENV"  # FLASK_ENV
         kwargs.setdefault("ENV_SWITCHER", env_prefix)


### PR DESCRIPTION
This transforms all kwargs in Flask/Django to upper case, making it possible for the user to pass `envvar_prefix` (and other kwargs) the same way as in the default `Dynaconf` class. The current behavior accepts only uppercase kwargs, making `envvar_prefix` not work as expected.

This also improves documentation for future use -> Line54 of the `flask.md` does need to be updated depending on which version when/if this get's released.