### PR TITLE
Load vault secrets from environment less stores or which are not written by dynaconf

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -646,7 +646,7 @@ class Settings:
         """Return the current active env"""
 
         if self.ENVIRONMENTS_FOR_DYNACONF is False:
-            return "main"
+            return self.MAIN_ENV_FOR_DYNACONF.lower()
 
         if self.FORCE_ENV_FOR_DYNACONF is not None:
             return self.FORCE_ENV_FOR_DYNACONF

--- a/dynaconf/default_settings.py
+++ b/dynaconf/default_settings.py
@@ -86,6 +86,7 @@ if not SETTINGS_FILE_FOR_DYNACONF and mispelled_files is not None:
 
 # If provided environments will be loaded separatelly
 ENVIRONMENTS_FOR_DYNACONF = get("ENVIRONMENTS_FOR_DYNACONF", False)
+MAIN_ENV_FOR_DYNACONF = get("MAIN_ENV_FOR_DYNACONF", "MAIN")
 
 # If False dynaconf will allow access to first level settings only in upper
 LOWERCASE_READ_FOR_DYNACONF = get("LOWERCASE_READ_FOR_DYNACONF", True)


### PR DESCRIPTION
Problem Statement:
--------------------

This PR fixes #723 !

The issue is observed when the secrets are created in Vault store without using DynaConf way of creating it that is CLI way of `dynaconf write` or using dynaconf APIs.

The secrets were directly created to `MOUNT_POINT/PATH` using Hashicorp vault CLI / API and hence the dynaconf environments were not created there. 

So while reading these non-dynaconf/non-environemnts based secrets from Vault using DynaConf, we were hitting to the wrong path, that is:
- if we set environments of dynaconf to True (`Dynaconf(environments=True)`) then we hit the developement enviroments path that is : `mount_point/path/developement`.
- if we set environments of dynaconf to False (`Dynaconf()`) then we hit the main environments path that is : `mount_point/path/main`.

Whereas in our case, we should hit to the `mount_point/path` path since we havent used DynaConfs environments based way of creating the secrets.

Solution:
----------

The proposed solution allows users to access both "DynaConfs `environments=False` secrets" as well as "Vault CLI/API pushed secrets (non-environment based)" by looking into both `mount_point/path/main` and direct `mount_point/path` directories.

This PR also fixes some vault v2 APIs accessing and removes unnecessary looping over `data` key for v2 secrets.