### PR TITLE
Use default value when settings is blank

### DIFF
--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -319,7 +319,7 @@ class Settings:
     def setdefault(self, item, default):
         """Returns value if exists or set it as the given default"""
         value = self.get(item, empty)
-        if value is empty and default is not empty:
+        if (not value or value is empty) and default is not empty:
             self.set(
                 item,
                 default,


### PR DESCRIPTION
Problem Statement:
-----------------------
Currently, when the value for a setting is blank in YAML, the dynaconf settings object is returning the None value instead of what's set as a default parameter.

The Validator example - `Validator('azurerm.client_secret', default='myAzurePass'),` is returning None when client_secret is set blank in azure.yaml

Expected:
-----------
When the Settings is set to blank in the YAML file then it must use the default value.

The Validator example - `Validator('azurerm.client_secret', default='myAzurePass'),` should return 'myAzurePass' when client_secret is set blank in azure.yaml

Solution:
----------
The `setdefault` method in the dynaconf settings class is updated to accept the value as blank to return the value from default parameter.