### PR TITLE
Added validate_only_current_env to validator (issue #734)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ test_examples:
 	cd example/issues/494_using_pathlib;pwd;python app.py
 	cd example/issues/519_underscore_in_name;pwd;ATC_BLE__device_id=42 EXPECTED_VALUE=42 python app.py
 	cd example/issues/519_underscore_in_name;pwd;ATC_BLE__DEVICE_ID=42 EXPECTED_VALUE=42 python app.py
+	cd example/issues/734_validate_only_current_env;pwd;python app.py
 
 test_vault:
 	# @cd example/vault;pwd;python write.py

--- a/dynaconf/base.py
+++ b/dynaconf/base.py
@@ -218,6 +218,9 @@ class Settings:
         self._not_installed_warnings = []
         self._validate_only = kwargs.pop("validate_only", None)
         self._validate_exclude = kwargs.pop("validate_exclude", None)
+        self._validate_only_current_env = kwargs.pop(
+            "validate_only_current_env", False
+        )
 
         self.validators = ValidatorList(
             self, validators=kwargs.pop("validators", None)
@@ -233,7 +236,9 @@ class Settings:
         self.execute_loaders()
 
         self.validators.validate(
-            only=self._validate_only, exclude=self._validate_exclude
+            only=self._validate_only,
+            exclude=self._validate_exclude,
+            only_current_env=self._validate_only_current_env,
         )
 
     def __call__(self, *args, **kwargs):
@@ -1221,5 +1226,6 @@ RESERVED_ATTRS = (
         "validators",
         "_validate_only",
         "_validate_exclude",
+        "_validate_only_current_env",
     ]
 )

--- a/example/issues/734_validate_only_current_env/app.py
+++ b/example/issues/734_validate_only_current_env/app.py
@@ -1,0 +1,30 @@
+from dynaconf import Dynaconf
+from dynaconf import ValidationError
+from dynaconf import Validator
+
+settings_dev = Dynaconf(
+    settings_files=["settings.toml"],
+    environments=True,
+    force_env="development",
+)
+
+settings_prod = Dynaconf(
+    settings_files=["settings.toml"], environments=True, force_env="production"
+)
+
+settings_dev.validators.register(
+    Validator("API_KEY", env="production", must_exist=True)
+)
+
+settings_prod.validators.register(
+    Validator("API_KEY", env="production", must_exist=True)
+)
+
+# Will not fail event if production env has no API_KEY
+settings_dev.validators.validate(only_current_env=True)
+
+# Will fail as production env has no API_KEY and current env is production
+try:
+    settings_prod.validators.validate(only_current_env=True)
+except ValidationError as e:
+    print(e)

--- a/example/issues/734_validate_only_current_env/settings.toml
+++ b/example/issues/734_validate_only_current_env/settings.toml
@@ -1,0 +1,13 @@
+[development]
+version = "dev"
+age = 35
+name = "Bruno"
+servers = ['127.0.0.1', 'localhost', 'development.com']
+PORT = 80
+
+[production]
+version = "1.0.0"
+age = 35
+name = "Bruno"
+servers = ['production.com']
+PORT = 443

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -606,6 +606,36 @@ def test_validator_exclude_post_register(
     settings.app.path = "/tmp/app_startup"
 
 
+def test_validator_only_current_env_valid(tmpdir):
+    tmpfile = tmpdir.join("settings.toml")
+    tmpfile.write(TOML)
+    settings = LazySettings(
+        settings_file=str(tmpfile),
+        environments=True,
+        ENV_FOR_DYNACONF="DEVELOPMENT",
+    )
+    settings.validators.register(
+        Validator("IMAGE_1", env="production", must_exist=True)
+    )
+    settings.validators.validate(only_current_env=True)
+
+
+def test_raises_only_current_env_invalid(tmpdir):
+    tmpfile = tmpdir.join("settings.toml")
+    tmpfile.write(TOML)
+    settings = LazySettings(
+        settings_file=str(tmpfile),
+        environments=True,
+        ENV_FOR_DYNACONF="PRODUCTION",
+    )
+    settings.validators.register(
+        Validator("IMAGE_1", env="production", must_exist=True)
+    )
+
+    with pytest.raises(ValidationError):
+        settings.validators.validate(only_current_env=True)
+
+
 def test_raises_on_invalid_selective_args(tmpdir, yaml_validators_good):
     settings = LazySettings(validators=yaml_validators_good, validate_only=int)
     with pytest.raises(ValueError):


### PR DESCRIPTION
As discussed in [issue 734](https://github.com/rochacbruno/dynaconf/issues/734), added a new keyword for `validator.validate` and `Settings` class to only run validators on current env instead of all defined envs.

Hope everything is fine, feel free to mention any issue and I'll try to fix them.