### PR TITLE
Using filter_strategy in env_loader to fix #760

### DIFF
--- a/dynaconf/loaders/env_loader.py
+++ b/dynaconf/loaders/env_loader.py
@@ -76,6 +76,9 @@ def load_from_env(
         }
         # Update the settings space based on gathered data from environment.
         if data:
+            filter_strategy = obj.get("FILTER_STRATEGY")
+            if filter_strategy:
+                data = filter_strategy(data)
             obj.update(data, loader_identifier=identifier)
 
 


### PR DESCRIPTION
Checks if `filter_strategy` is set and uses it in `env_loader`. The other loaders are using the `BaseLoader` that already executes the `filter_strategy` by default, so no need to change them. 😄 